### PR TITLE
skip assets when generating scaffolds by default

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module VoicesOfConsent
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
+    config.generators.assets = false
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
Resolves #39 

### Description
when running `rails g scaffold MyModel`, assets are now skipped by default

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Yes, when generating a scaffold, assets are skipped