### PR TITLE
Allow RSpec in the development environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem "rspec-rails", "~> 3.8"
 end
 
 group :development do
@@ -43,7 +44,6 @@ group :test do
   gem 'selenium-webdriver'
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'chromedriver-helper'
-  gem "rspec-rails", "~> 3.8"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem


### PR DESCRIPTION
Currently, `rspec-rails` is not loaded in the development environment, so things like `rails g model` will not generate model specs. This PR moves `rspec-rails` to be loaded in the development environment to ensure that the Rails generators also generate specs.