### PR TITLE
move rspec-rails to dev and test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem "rspec-rails", "~> 3.8"
 end
 
 group :development do
@@ -43,7 +44,6 @@ group :test do
   gem 'selenium-webdriver'
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'chromedriver-helper'
-  gem "rspec-rails", "~> 3.8"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem


### PR DESCRIPTION
### Description

rspec-rails needs to be in the development group for rails generate to create rspec tests instead of minitests.
