### PR TITLE
Add explicit height to navbar icons

### DIFF
--- a/app/javascript/src/stylesheets/application.scss
+++ b/app/javascript/src/stylesheets/application.scss
@@ -20,9 +20,18 @@
 a.nav-icon {
     border-right: solid 2px rgb(170, 150, 153);
     padding: 0 1em;
+    max-height: 80px;
     flex: 1 0 auto;
 
     &.home-nav-icon {
         flex-grow: 2.75;
     }
+
+    img {
+      max-height: 80px;
+    }
+}
+
+body {
+  padding-top: 100px;
 }


### PR DESCRIPTION
This keeps them from growing too large

## Before

<img width="713" alt="image" src="https://user-images.githubusercontent.com/108205/62009177-440dab00-b12a-11e9-9e7c-0aaed7529c8a.png">

## After

<img width="708" alt="image" src="https://user-images.githubusercontent.com/108205/62009181-4c65e600-b12a-11e9-99d2-cc1402a2e004.png">
