### PR TITLE
turn on authentication globally instead of in each controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,10 @@
 class ApplicationController < ActionController::Base
   include Pundit
-  before_action :store_user_location!, if: :storable_location?
+
   protect_from_forgery
+  before_action :store_user_location!, if: :storable_location?
+  before_action :authenticate_user!
+
   layout 'application_full'
 
   private

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -1,5 +1,4 @@
 class AttendancesController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_attendance, only: [:show, :edit, :update, :destroy]
 
   # GET /attendances

--- a/app/controllers/box_assembly_controller.rb
+++ b/app/controllers/box_assembly_controller.rb
@@ -1,5 +1,4 @@
 class BoxAssemblyController < ApplicationController
-  before_action :authenticate_user!
 
   def new
   end

--- a/app/controllers/box_design_controller.rb
+++ b/app/controllers/box_design_controller.rb
@@ -1,9 +1,8 @@
 class BoxDesignController < ApplicationController
-  before_action :authenticate_user!
 
   def new
   end
-  
+
   def claim
     @box = box_claim_scope.find(params[:box_id])
     @box.designed_by = current_user

--- a/app/controllers/box_shipment_controller.rb
+++ b/app/controllers/box_shipment_controller.rb
@@ -1,5 +1,4 @@
 class BoxShipmentController < ApplicationController
-  before_action :authenticate_user!
 
   def claim
     @box = Box.includes(:box_request).find_by_id(params[:box_id])

--- a/app/controllers/boxes_controller.rb
+++ b/app/controllers/boxes_controller.rb
@@ -1,5 +1,4 @@
 class BoxesController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_box, only: [:show, :edit, :update, :destroy]
 
   # GET /boxes

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,5 @@
 class HomeController < ApplicationController
-before_action :authenticate_user!, only: [:admin]
-
+  skip_before_action :authenticate_user!, only: [:contact]
 
   def index
   end

--- a/app/controllers/inventory_adjustments_controller.rb
+++ b/app/controllers/inventory_adjustments_controller.rb
@@ -1,5 +1,4 @@
 class InventoryAdjustmentsController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_inventory_adjustment, only: [:show, :edit, :update, :destroy]
 
   # GET /inventory_adjustments

--- a/app/controllers/inventory_types_controller.rb
+++ b/app/controllers/inventory_types_controller.rb
@@ -1,5 +1,4 @@
 class InventoryTypesController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_inventory_type, only: [:show, :edit, :update, :destroy]
 
   # GET /inventory_types

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -1,5 +1,4 @@
 class LocationsController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_location, only: [:show, :edit, :update, :destroy]
 
   # GET /locations

--- a/app/controllers/meeting_types_controller.rb
+++ b/app/controllers/meeting_types_controller.rb
@@ -1,5 +1,4 @@
 class MeetingTypesController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_meeting_type, only: [:show, :edit, :update, :destroy]
 
   # GET /meeting_types

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -1,5 +1,4 @@
 class MeetingsController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_meeting, only: [:show, :edit, :update, :destroy]
 
   # GET /meetings

--- a/app/controllers/message_logs_controller.rb
+++ b/app/controllers/message_logs_controller.rb
@@ -1,5 +1,4 @@
 class MessageLogsController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_message_log, only: [:show, :edit, :update, :destroy]
 
   # GET /message_logs

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -1,5 +1,4 @@
 class PurchasesController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_purchase, only: [:show, :edit, :update, :destroy]
 
   # GET /purchases

--- a/app/controllers/requesters_controller.rb
+++ b/app/controllers/requesters_controller.rb
@@ -1,6 +1,6 @@
 class RequestersController < ApplicationController
+  skip_before_action :authenticate_user!, only: [:new]
   before_action :set_requester, only: [:show, :edit, :update, :destroy]
-  layout "box_request_layout"
 
   # GET /requesters
   # GET /requesters.json
@@ -16,6 +16,7 @@ class RequestersController < ApplicationController
   # GET /requesters/new
   def new
     @requester = Requester.new
+    render :new, layout: 'box_request_layout'
   end
 
   # GET /requesters/1/edit

--- a/app/controllers/user_management_controller.rb
+++ b/app/controllers/user_management_controller.rb
@@ -1,5 +1,4 @@
 class UserManagementController < ApplicationController
-  before_action :authenticate_user!
   def show
   end
 end

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -1,5 +1,4 @@
 class VolunteersController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_volunteer, only: [:show, :edit, :update, :destroy]
 
   # GET /volunteers


### PR DESCRIPTION
This prevents us from ever getting caught out, authentication-wise, when introducing a new controller. 

It also more clearly expresses the basic nature of authentication in the app. Authentication is _always_ required for people who are looking at data here. In very few exceptional cases is anything open to the public.