### PR TITLE
Add thank you (confirmation) page after requesters/new box_request creation

### DIFF
--- a/app/controllers/box_request_triage_controller.rb
+++ b/app/controllers/box_request_triage_controller.rb
@@ -55,7 +55,8 @@ class BoxRequestTriageController < ApplicationController
 
     box_request.save!
 
-    head :found, location: box_request_thank_you_path(format: :json)
+    render json: { "redirect_url": box_request_thank_you_path },
+           status: 200
   end
 
   private

--- a/app/controllers/box_request_triage_controller.rb
+++ b/app/controllers/box_request_triage_controller.rb
@@ -54,6 +54,7 @@ class BoxRequestTriageController < ApplicationController
 
     box_request.save!
 
+    head :found, location: box_request_thank_you_path(format: :json)
   end
 
   private

--- a/app/controllers/box_request_triage_controller.rb
+++ b/app/controllers/box_request_triage_controller.rb
@@ -1,4 +1,5 @@
 class BoxRequestTriageController < ApplicationController
+  skip_before_action :authenticate_user!, only: :create
 
   def create
     if params[:boxRequest].nil? || request_params.empty?

--- a/app/controllers/requesters_controller.rb
+++ b/app/controllers/requesters_controller.rb
@@ -1,5 +1,5 @@
 class RequestersController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:new]
+  skip_before_action :authenticate_user!, only: [:new, :thank_you]
   before_action :set_requester, only: [:show, :edit, :update, :destroy]
 
   # GET /requesters
@@ -60,6 +60,12 @@ class RequestersController < ApplicationController
     respond_to do |format|
       format.html { redirect_to requesters_url, notice: 'Requester was successfully destroyed.' }
       format.json { head :no_content }
+    end
+  end
+
+  def thank_you
+    respond_to do |format|
+      format.html { render :layout => "box_request_layout" }
     end
   end
 

--- a/app/javascript/src/components/box-request-form/BoxRequestForm.js
+++ b/app/javascript/src/components/box-request-form/BoxRequestForm.js
@@ -88,6 +88,12 @@ class BoxRequestForm extends React.Component {
         'X-CSRF-Token': token
       },
       body: JSON.stringify(this.state)
+    })
+    .then((response) => {
+      return response.json()
+    })
+    .then((data) => {
+      window.location.href = data.redirect_url;
     });
   }
 

--- a/app/views/requesters/thank_you.html.erb
+++ b/app/views/requesters/thank_you.html.erb
@@ -1,0 +1,3 @@
+<h1 class="text-center">
+  Thank you!
+</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,17 +1,8 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
-  resources :purchases
-  resources :inventory_adjustments
-  resources :inventory_tallies
-  resources :inventory_types
-  resources :locations
-  resources :meeting_types
-  resources :attendances
-  resources :box_request_abuse_types
-  resources :message_logs
   devise_for :users, controllers: {
-    passwords: 'users/passwords', sessions: "users/sessions", invitations: "users/invitations"
+      passwords: 'users/passwords', sessions: "users/sessions", invitations: "users/invitations"
   }
   devise_scope :users do
     authenticated :user do
@@ -19,15 +10,32 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :meetings
-  resources :boxes
-  resources :volunteers
+  resources :attendances
+  resources :box_request_abuse_types
   resources :box_requests
-  resources :requesters, only: [:new]
+  resources :boxes
+  resources :inventory_adjustments
+  resources :inventory_tallies
+  resources :inventory_types
+  resources :locations
+  resources :meeting_types
+  resources :meetings
+  resources :message_logs
+  resources :purchases
+  resource :user_management, only: %i[show create destroy], controller: :user_management
+  resources :volunteers
 
   get 'login_demo/index'
   get 'contact', to: 'home#contact'
   get 'admin', to: 'home#admin'
+
+  # resources :requesters, only: %i[new thank_you], controller: :requesters
+
+  get 'requesters/new', to: 'requesters#new'
+  get 'requesters/thank_you', to: 'requesters#thank_you', as: 'box_request_thank_you'
+
+  post 'box_request_triage', to: "box_request_triage#create"
+  get 'box_request/already_claimed', to: 'box_requests#already_claimed'
 
   get 'box_design/new', to: 'box_design#new'
   get 'box_design/claim/:box_id', to: 'box_design#claim'
@@ -36,11 +44,6 @@ Rails.application.routes.draw do
   get 'box_assembly/new', to: 'box_assembly#new'
   get 'box_assembly/claim/:box_id', to: 'box_assembly#claim'
   post 'box_assembly/mark_as_assembled/:box_id', to: 'box_assembly#mark_as_assemblyed'
-
-  resource :user_management, only: %i[show create destroy], controller: :user_management
-
-  post 'box_request_triage', to: "box_request_triage#create"
-  get 'box_request/already_claimed', to: 'box_requests#already_claimed'
 
   get 'box_shipment/claim/:box_id', to: 'box_shipment#claim'
   post 'box_shipment/mark_as_shipped', to: 'box_shipment#mark_as_shipped'

--- a/spec/controllers/box_request_triage_controller_spec.rb
+++ b/spec/controllers/box_request_triage_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe BoxRequestTriageController, type: :controller do
     it "will complain if no data is submitted" do
       post :create
 
-      expect(response.success?).to be_falsey
+      expect(response.successful?).to be_falsey
     end
 
     it "will save an email address" do

--- a/spec/controllers/box_request_triage_controller_spec.rb
+++ b/spec/controllers/box_request_triage_controller_spec.rb
@@ -57,5 +57,10 @@ RSpec.describe BoxRequestTriageController, type: :controller do
       expect(box_request.summary).to eql(expected_summary)
       expect(box_request.is_interested_in_counseling_services).to eql(expected_counseling)
     end
+
+    it "returns redirect_url with a succesful submission" do
+      post :create, :params => { :boxRequest => test_data }
+      expect(JSON.parse(response.body)).to include("redirect_url" => box_request_thank_you_path)
+    end
   end
 end


### PR DESCRIPTION
Fixes #162

Add rails "thank you" page that unauthenticated users (requesters) should be redirected to after completing a BoxRequest (requesters/new form)

- [x] test for controller responding with a redirect URI
- [ ] test for the react frontend ..uh.. reacting to the redirect URI