### PR TITLE
genericize the example database config

### DIFF
--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -19,9 +19,7 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
-  username: postgres
-  password: password
-  host: postgres
+  host: localhost
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:


### PR DESCRIPTION
The previous example config was specific to one of the developers. Most Rails dev environments run PostgreSQL on localhost with a login that matches the OS user.