### PR TITLE
Box requests footer bug

### DIFF
--- a/app/javascript/src/stylesheets/application.scss
+++ b/app/javascript/src/stylesheets/application.scss
@@ -20,9 +20,16 @@ body {
 }
 
 .container {
-    background-color: white;
-    height: 100%;
+    background-color: white;    
+    flex: 1;
+    margin-bottom: 170px;
+
 }
+
+.responsive-table {
+
+}
+
 .app-nav {
     position: fixed;
     top: 0;
@@ -58,4 +65,8 @@ a.nav-icon {
 
 footer {
     background-color: #eee;
+    position: fixed; 
+    width: 100%; 
+    bottom: 0
+
 }

--- a/app/javascript/src/stylesheets/application.scss
+++ b/app/javascript/src/stylesheets/application.scss
@@ -25,11 +25,6 @@ body {
     margin-bottom: 170px;
 
 }
-
-.responsive-table {
-
-}
-
 .app-nav {
     position: fixed;
     top: 0;
@@ -68,5 +63,4 @@ footer {
     position: fixed; 
     width: 100%; 
     bottom: 0
-
 }

--- a/app/views/box_requests/index.html.erb
+++ b/app/views/box_requests/index.html.erb
@@ -26,8 +26,8 @@
       <th>Followup sent?</th>
     </tr>
   </thead>
-  
-  <tbody >
+
+  <tbody>
     <% @box_requests.each do |box_request| %>
       <tr>
         <td><%= box_request.id %></td>

--- a/app/views/box_requests/index.html.erb
+++ b/app/views/box_requests/index.html.erb
@@ -26,6 +26,7 @@
       <th>Followup sent?</th>
     </tr>
   </thead>
+  
   <tbody >
     <% @box_requests.each do |box_request| %>
       <tr>

--- a/app/views/box_requests/index.html.erb
+++ b/app/views/box_requests/index.html.erb
@@ -15,7 +15,6 @@
   <button>Sort this list</button>
 </form>
 
-
 <table class="table box-requests-table">
   <thead>
     <tr>
@@ -27,11 +26,6 @@
       <th>Followup sent?</th>
     </tr>
   </thead>
-
-
-
-
-
   <tbody >
     <% @box_requests.each do |box_request| %>
       <tr>

--- a/app/views/box_requests/index.html.erb
+++ b/app/views/box_requests/index.html.erb
@@ -15,6 +15,7 @@
   <button>Sort this list</button>
 </form>
 
+
 <table class="table box-requests-table">
   <thead>
     <tr>
@@ -27,7 +28,11 @@
     </tr>
   </thead>
 
-  <tbody>
+
+
+
+
+  <tbody >
     <% @box_requests.each do |box_request| %>
       <tr>
         <td><%= box_request.id %></td>
@@ -47,4 +52,3 @@
     <% end %>
   </tbody>
 </table>
-<br>


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #161 
### Description

This merge request resolves issue [#161](https://github.com/rubyforgood/voices-of-consent/issues/161) which caused the footer to be positioned at the centre of the page when box_requests increased. Now the footer is fixed and remains at the bottom of the page.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that 
we can reproduce? -->

Tested the changes on my local machine and everything works as expected.

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight 
edited element.-->

Previous Footer:
![Screenshot 2019-08-11 at 22 07 37](https://user-images.githubusercontent.com/51298718/62839965-bfbf3a00-bc8a-11e9-8bf3-82daca8c9fbf.png)

Fixed Footer:
![Screenshot 2019-08-11 at 22 55 03](https://user-images.githubusercontent.com/51298718/62839987-19bfff80-bc8b-11e9-8ba0-a540186f2fa9.png)

