### PR TITLE
Streamline inventory counts

### DIFF
--- a/app/controllers/inventory_adjustments_controller.rb
+++ b/app/controllers/inventory_adjustments_controller.rb
@@ -69,6 +69,10 @@ class InventoryAdjustmentsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def inventory_adjustment_params
-      params.require(:inventory_adjustment).permit(:inventory_tally_id, :purchase_id, :box_item_id, :total_cost, :tally_quantity_start, :tally_quantity_end, :adjustment_quantity)
+      params.require(:inventory_adjustment).permit(:inventory_tally_id,
+                                                   :purchase_id,
+                                                   :box_item_id,
+                                                   :total_cost,
+                                                   :adjustment_quantity)
     end
 end

--- a/app/controllers/inventory_tallies_controller.rb
+++ b/app/controllers/inventory_tallies_controller.rb
@@ -69,6 +69,8 @@ class InventoryTalliesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def inventory_tally_params
-      params.require(:inventory_tally).permit(:additional_location_info, :cached_quantity, :inventory_type_id, :storage_location_id)
+      params.require(:inventory_tally).permit(:additional_location_info,
+                                              :inventory_type_id,
+                                              :storage_location_id)
     end
 end

--- a/app/models/inventory_adjustment.rb
+++ b/app/models/inventory_adjustment.rb
@@ -4,14 +4,4 @@ class InventoryAdjustment < ApplicationRecord
   belongs_to :box_item, optional: true
 
   validates :inventory_tally, presence: true
-
-  before_save :adjust_cached_inventory_quantity
-
-  def adjust_cached_inventory_quantity
-    self.tally_quantity_start = self.inventory_tally.cached_quantity
-    self.tally_quantity_end = self.tally_quantity_start + self.adjustment_quantity
-
-    # TODO: need to decide how to handle self.tally_quantity_end < 0
-    self.inventory_tally.update_attribute(:cached_quantity, self.tally_quantity_end)
-  end
 end

--- a/app/views/inventory_adjustments/_form.html.erb
+++ b/app/views/inventory_adjustments/_form.html.erb
@@ -15,8 +15,6 @@
       <%= f.association :purchase %>
       <%= f.association :box_item %>
       <%= f.input :total_cost %>
-      <%= f.input :tally_quantity_start %>
-      <%= f.input :tally_quantity_end %>
       <%= f.input :adjustment_quantity %>
   </div>
 

--- a/app/views/inventory_adjustments/_inventory_adjustment.json.jbuilder
+++ b/app/views/inventory_adjustments/_inventory_adjustment.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! inventory_adjustment, :id, :inventory_tally_id, :purchase_id, :box_item_id, :total_cost, :tally_quantity_start, :tally_quantity_end, :adjustment_quantity, :created_at, :updated_at
+json.extract! inventory_adjustment, :id, :inventory_tally_id, :purchase_id, :box_item_id, :total_cost, :adjustment_quantity, :created_at, :updated_at
 json.url inventory_adjustment_url(inventory_adjustment, format: :json)

--- a/app/views/inventory_adjustments/index.html.erb
+++ b/app/views/inventory_adjustments/index.html.erb
@@ -9,8 +9,6 @@
       <th>Purchase</th>
       <th>Box item</th>
       <th>Total cost</th>
-      <th>Tally quantity start</th>
-      <th>Tally quantity end</th>
       <th>Adjustment quantity</th>
       <th colspan="3"></th>
     </tr>
@@ -23,8 +21,6 @@
         <td><%= inventory_adjustment.purchase %></td>
         <td><%= inventory_adjustment.box_item %></td>
         <td><%= inventory_adjustment.total_cost %></td>
-        <td><%= inventory_adjustment.tally_quantity_start %></td>
-        <td><%= inventory_adjustment.tally_quantity_end %></td>
         <td><%= inventory_adjustment.adjustment_quantity %></td>
         <td><%= link_to 'Show', inventory_adjustment %></td>
         <td><%= link_to 'Edit', edit_inventory_adjustment_path(inventory_adjustment) %></td>

--- a/app/views/inventory_adjustments/show.html.erb
+++ b/app/views/inventory_adjustments/show.html.erb
@@ -21,16 +21,6 @@
 </p>
 
 <p>
-  <strong>Tally quantity start:</strong>
-  <%= @inventory_adjustment.tally_quantity_start %>
-</p>
-
-<p>
-  <strong>Tally quantity end:</strong>
-  <%= @inventory_adjustment.tally_quantity_end %>
-</p>
-
-<p>
   <strong>Adjustment quantity:</strong>
   <%= @inventory_adjustment.adjustment_quantity %>
 </p>

--- a/app/views/inventory_tallies/_form.html.erb
+++ b/app/views/inventory_tallies/_form.html.erb
@@ -12,7 +12,6 @@
 
   <div class="form-inputs container">
       <%= f.input :additional_location_info %>
-      <%= f.input :cached_quantity %>
       <%= f.association :inventory_type %>
       <%= f.association :storage_location %>
   </div>

--- a/app/views/inventory_tallies/_inventory_tally.json.jbuilder
+++ b/app/views/inventory_tallies/_inventory_tally.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! inventory_tally, :id, :additional_location_info, :cached_quantity, :inventory_type_id, :storage_location_id, :created_at, :updated_at
+json.extract! inventory_tally, :id, :additional_location_info, :inventory_type_id, :storage_location_id, :created_at, :updated_at
 json.url inventory_tally_url(inventory_tally, format: :json)

--- a/app/views/inventory_tallies/index.html.erb
+++ b/app/views/inventory_tallies/index.html.erb
@@ -6,7 +6,6 @@
   <thead>
     <tr>
       <th>Additional location info</th>
-      <th>Cached quantity</th>
       <th>Inventory type</th>
       <th>Storage location</th>
       <th colspan="3"></th>
@@ -17,7 +16,6 @@
     <% @inventory_tallies.each do |inventory_tally| %>
       <tr>
         <td><%= inventory_tally.additional_location_info %></td>
-        <td><%= inventory_tally.cached_quantity %></td>
         <td><%= inventory_tally.inventory_type %></td>
         <td><%= inventory_tally.storage_location %></td>
         <td><%= link_to 'Show', inventory_tally %></td>

--- a/app/views/inventory_tallies/show.html.erb
+++ b/app/views/inventory_tallies/show.html.erb
@@ -6,11 +6,6 @@
 </p>
 
 <p>
-  <strong>Cached quantity:</strong>
-  <%= @inventory_tally.cached_quantity %>
-</p>
-
-<p>
   <strong>Inventory type:</strong>
   <%= @inventory_tally.inventory_type %>
 </p>

--- a/db/migrate/20190810162817_streamline_inventory_counts.rb
+++ b/db/migrate/20190810162817_streamline_inventory_counts.rb
@@ -1,0 +1,7 @@
+class StreamlineInventoryCounts < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :inventory_tallies, :cached_quantity, :integer
+    remove_column :inventory_adjustments, :tally_quantity_end, :integer
+    remove_column :inventory_adjustments, :tally_quantity_start, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_09_191704) do
+ActiveRecord::Schema.define(version: 2019_08_10_162817) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -129,8 +129,6 @@ ActiveRecord::Schema.define(version: 2019_08_09_191704) do
     t.bigint "purchase_id"
     t.bigint "box_item_id"
     t.integer "total_cost"
-    t.integer "tally_quantity_start"
-    t.integer "tally_quantity_end"
     t.integer "adjustment_quantity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -141,7 +139,6 @@ ActiveRecord::Schema.define(version: 2019_08_09_191704) do
 
   create_table "inventory_tallies", force: :cascade do |t|
     t.string "additional_location_info"
-    t.integer "cached_quantity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "inventory_type_id"

--- a/notes/database-diagram.dot
+++ b/notes/database-diagram.dot
@@ -206,7 +206,6 @@ digraph G {
                     storage_location_id (location)\n
                     additional_location_info:string\n
                     file_upload\n
-                    cached_quantity (not editable by user)\n
                     }"]
     InventoryAdjustment [
                 shape=record;
@@ -215,9 +214,7 @@ digraph G {
                     purchase_id (optional)\n
                     total_cost (optional)\n
                     box_item_id (optional)\n
-                    tally_quantity_start:int (not editable by user)\n
-                    tally_quantity_end:int (not editable by user)\n
-                    adjustment_quantity:int (positive or negative count, which \nchanges inventory_tally#cached_quantity)\n
+                    adjustment_quantity:int (positive or negative count)\n
 
                     }"]
     User [

--- a/spec/factories/inventory_adjustments.rb
+++ b/spec/factories/inventory_adjustments.rb
@@ -4,8 +4,6 @@ FactoryBot.define do
     purchase { nil }
     box_item { nil }
     total_cost { 1 }
-    tally_quantity_start { 1 }
-    tally_quantity_end { 1 }
     adjustment_quantity { 1 }
   end
 end

--- a/spec/factories/inventory_tallies.rb
+++ b/spec/factories/inventory_tallies.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :inventory_tally do
     additional_location_info { "MyString" }
-    cached_quantity { 1 }
     inventory_type { nil }
     storage_location { nil }
   end

--- a/spec/views/inventory_adjustments/edit.html.erb_spec.rb
+++ b/spec/views/inventory_adjustments/edit.html.erb_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe "inventory_adjustments/edit", type: :view do
       :purchase => nil,
       :box_item => nil,
       :total_cost => 1,
-      :tally_quantity_start => 1,
-      :tally_quantity_end => 1,
       :adjustment_quantity => 1
     ))
   end
@@ -25,10 +23,6 @@ RSpec.describe "inventory_adjustments/edit", type: :view do
       assert_select "input[name=?]", "inventory_adjustment[box_item_id]"
 
       assert_select "input[name=?]", "inventory_adjustment[total_cost]"
-
-      assert_select "input[name=?]", "inventory_adjustment[tally_quantity_start]"
-
-      assert_select "input[name=?]", "inventory_adjustment[tally_quantity_end]"
 
       assert_select "input[name=?]", "inventory_adjustment[adjustment_quantity]"
     end

--- a/spec/views/inventory_adjustments/index.html.erb_spec.rb
+++ b/spec/views/inventory_adjustments/index.html.erb_spec.rb
@@ -8,8 +8,6 @@ RSpec.describe "inventory_adjustments/index", type: :view do
         :purchase => nil,
         :box_item => nil,
         :total_cost => 2,
-        :tally_quantity_start => 3,
-        :tally_quantity_end => 4,
         :adjustment_quantity => 5
       ),
       InventoryAdjustment.create!(
@@ -17,8 +15,6 @@ RSpec.describe "inventory_adjustments/index", type: :view do
         :purchase => nil,
         :box_item => nil,
         :total_cost => 2,
-        :tally_quantity_start => 3,
-        :tally_quantity_end => 4,
         :adjustment_quantity => 5
       )
     ])
@@ -30,8 +26,6 @@ RSpec.describe "inventory_adjustments/index", type: :view do
     assert_select "tr>td", :text => nil.to_s, :count => 2
     assert_select "tr>td", :text => nil.to_s, :count => 2
     assert_select "tr>td", :text => 2.to_s, :count => 2
-    assert_select "tr>td", :text => 3.to_s, :count => 2
-    assert_select "tr>td", :text => 4.to_s, :count => 2
     assert_select "tr>td", :text => 5.to_s, :count => 2
   end
 end

--- a/spec/views/inventory_adjustments/new.html.erb_spec.rb
+++ b/spec/views/inventory_adjustments/new.html.erb_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe "inventory_adjustments/new", type: :view do
       :purchase => nil,
       :box_item => nil,
       :total_cost => 1,
-      :tally_quantity_start => 1,
-      :tally_quantity_end => 1,
       :adjustment_quantity => 1
     ))
   end
@@ -25,10 +23,6 @@ RSpec.describe "inventory_adjustments/new", type: :view do
       assert_select "input[name=?]", "inventory_adjustment[box_item_id]"
 
       assert_select "input[name=?]", "inventory_adjustment[total_cost]"
-
-      assert_select "input[name=?]", "inventory_adjustment[tally_quantity_start]"
-
-      assert_select "input[name=?]", "inventory_adjustment[tally_quantity_end]"
 
       assert_select "input[name=?]", "inventory_adjustment[adjustment_quantity]"
     end

--- a/spec/views/inventory_adjustments/show.html.erb_spec.rb
+++ b/spec/views/inventory_adjustments/show.html.erb_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe "inventory_adjustments/show", type: :view do
       :purchase => nil,
       :box_item => nil,
       :total_cost => 2,
-      :tally_quantity_start => 3,
-      :tally_quantity_end => 4,
       :adjustment_quantity => 5
     ))
   end
@@ -19,8 +17,6 @@ RSpec.describe "inventory_adjustments/show", type: :view do
     expect(rendered).to match(//)
     expect(rendered).to match(//)
     expect(rendered).to match(/2/)
-    expect(rendered).to match(/3/)
-    expect(rendered).to match(/4/)
     expect(rendered).to match(/5/)
   end
 end

--- a/spec/views/inventory_tallies/edit.html.erb_spec.rb
+++ b/spec/views/inventory_tallies/edit.html.erb_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe "inventory_tallies/edit", type: :view do
   before(:each) do
     @inventory_tally = assign(:inventory_tally, InventoryTally.create!(
       :additional_location_info => "MyString",
-      :cached_quantity => 1,
       :inventory_type => nil,
       :storage_location => nil
     ))
@@ -16,8 +15,6 @@ RSpec.describe "inventory_tallies/edit", type: :view do
     assert_select "form[action=?][method=?]", inventory_tally_path(@inventory_tally), "post" do
 
       assert_select "input[name=?]", "inventory_tally[additional_location_info]"
-
-      assert_select "input[name=?]", "inventory_tally[cached_quantity]"
 
       assert_select "input[name=?]", "inventory_tally[inventory_type_id]"
 

--- a/spec/views/inventory_tallies/index.html.erb_spec.rb
+++ b/spec/views/inventory_tallies/index.html.erb_spec.rb
@@ -5,13 +5,11 @@ RSpec.describe "inventory_tallies/index", type: :view do
     assign(:inventory_tallies, [
       InventoryTally.create!(
         :additional_location_info => "Additional Location Info",
-        :cached_quantity => 2,
         :inventory_type => nil,
         :storage_location => nil
       ),
       InventoryTally.create!(
         :additional_location_info => "Additional Location Info",
-        :cached_quantity => 2,
         :inventory_type => nil,
         :storage_location => nil
       )

--- a/spec/views/inventory_tallies/new.html.erb_spec.rb
+++ b/spec/views/inventory_tallies/new.html.erb_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe "inventory_tallies/new", type: :view do
   before(:each) do
     assign(:inventory_tally, InventoryTally.new(
       :additional_location_info => "MyString",
-      :cached_quantity => 1,
       :inventory_type => nil,
       :storage_location => nil
     ))
@@ -16,8 +15,6 @@ RSpec.describe "inventory_tallies/new", type: :view do
     assert_select "form[action=?][method=?]", inventory_tallies_path, "post" do
 
       assert_select "input[name=?]", "inventory_tally[additional_location_info]"
-
-      assert_select "input[name=?]", "inventory_tally[cached_quantity]"
 
       assert_select "input[name=?]", "inventory_tally[inventory_type_id]"
 

--- a/spec/views/inventory_tallies/show.html.erb_spec.rb
+++ b/spec/views/inventory_tallies/show.html.erb_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe "inventory_tallies/show", type: :view do
   before(:each) do
     @inventory_tally = assign(:inventory_tally, InventoryTally.create!(
       :additional_location_info => "Additional Location Info",
-      :cached_quantity => 2,
       :inventory_type => nil,
       :storage_location => nil
     ))
@@ -13,7 +12,6 @@ RSpec.describe "inventory_tallies/show", type: :view do
   it "renders attributes in <p>" do
     render
     expect(rendered).to match(/Additional Location Info/)
-    expect(rendered).to match(/2/)
     expect(rendered).to match(//)
     expect(rendered).to match(//)
   end


### PR DESCRIPTION
- Remove cached_quantity from inventory_tallies
- Remove tally_quantity_start and tally_quantity_end from inventory_adjustments
- This removes a callback, and maybe we need to reimplement something similar
in the future, but simplifying for now bc it's likely a YAGNI situation

