### PR TITLE
Devise

### DIFF
--- a/app/javascript/src/stylesheets/application.scss
+++ b/app/javascript/src/stylesheets/application.scss
@@ -25,6 +25,11 @@ body {
     margin-bottom: 170px;
 
 }
+
+.flash-mesages {
+    margin-left: 10px;
+}
+
 .app-nav {
     position: fixed;
     top: 0;

--- a/app/javascript/src/stylesheets/application.scss
+++ b/app/javascript/src/stylesheets/application.scss
@@ -26,7 +26,7 @@ body {
 
 }
 
-.flash-mesages {
+.flash-messages {
     margin-left: 10px;
 }
 

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Log in</h2>
 
 <% if flash.alert %>
-  <div class="flash-mesages">
+  <div class="flash-messages">
     <ul>
       <li><%= flash.alert %></li>
     </ul>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,5 +1,13 @@
 <h2>Log in</h2>
 
+<% if flash.alert %>
+  <div class="flash-mesages">
+    <ul>
+      <li><%= flash.alert %></li>
+    </ul>
+  </div>
+<% end %>
+
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
     <%= f.label :email %><br />


### PR DESCRIPTION

Resolves #147  <!--fill issue number-->

### Description 
Flash messages are now displayed if a user attempts to sign in with an incorrect password, or email.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested on my local machine and flash messages correctly appear when incorrect email / password is inputted.

### Screenshots
**Before**
![Screenshot 2019-08-18 at 15 20 54](https://user-images.githubusercontent.com/51298718/63225816-9d6a7680-c1cc-11e9-963d-f4914ab54c73.png)

**After**
![Screenshot 2019-08-18 at 15 20 43](https://user-images.githubusercontent.com/51298718/63225818-a65b4800-c1cc-11e9-9a2b-d3e35f4fe34b.png)

