### PR TITLE
157 update requesters/new required params

### DIFF
--- a/app/javascript/src/components/box-request-form/BoxRequestForm.js
+++ b/app/javascript/src/components/box-request-form/BoxRequestForm.js
@@ -334,7 +334,7 @@ class BoxRequestForm extends React.Component {
 
           <div class="row section-top">
             <label class="section-label">Phone</label>
-            <input type="text" class="form-control" name="phone" value={boxRequest.phone} onChange={this.handleChange} />
+            <input type="text" class="form-control" name="phone" for="phone_number_entered" value={boxRequest.phone} onChange={this.handleChange} />
             <div class="col-6"> 
               <div class="row">
                 <label class="following-question">Okay to call?*</label>
@@ -363,7 +363,7 @@ class BoxRequestForm extends React.Component {
               </div>
             </div>
           </div>
-          { this.state.attemptedSubmit && (boxRequest.ok_to_text == null || boxRequest.ok_to_call == null) ? this.renderRequiredAlert() : null }
+          { this.state.attemptedSubmit && boxRequest.phone_number_entered !== null && (boxRequest.ok_to_text == null || boxRequest.ok_to_call == null) ? this.renderRequiredAlert() : null }
 
           <div class="row section-top">
             <label>Are you requesting this box for someone else? If so, please briefly explain. </label>

--- a/app/javascript/src/components/box-request-form/BoxRequestForm.js
+++ b/app/javascript/src/components/box-request-form/BoxRequestForm.js
@@ -363,7 +363,7 @@ class BoxRequestForm extends React.Component {
               </div>
             </div>
           </div>
-          { this.state.attemptedSubmit && boxRequest.phone_number_entered !== null && (boxRequest.ok_to_text == null || boxRequest.ok_to_call == null) ? this.renderRequiredAlert() : null }
+          { this.state.attemptedSubmit && boxRequest.phone != '' && (boxRequest.ok_to_text == null || boxRequest.ok_to_call == null) ? this.renderRequiredAlert() : null }
 
           <div class="row section-top">
             <label>Are you requesting this box for someone else? If so, please briefly explain. </label>

--- a/app/javascript/src/components/box-request-form/BoxRequestForm.js
+++ b/app/javascript/src/components/box-request-form/BoxRequestForm.js
@@ -334,10 +334,10 @@ class BoxRequestForm extends React.Component {
 
           <div class="row section-top">
             <label class="section-label">Phone</label>
-            <input type="text" class="form-control" name="phone" for="phone_number_entered" value={boxRequest.phone} onChange={this.handleChange} />
+            <input type="text" class="form-control" name="phone" value={boxRequest.phone} onChange={this.handleChange} />
             <div class="col-6"> 
               <div class="row">
-                <label class="following-question">Okay to call?*</label>
+                <label class="following-question">Okay to call?</label>
                 <div class="form-check form-check-inline">
                   <input class="form-check-input" type="radio" name="ok_to_call" id="ok_to_call_true" onChange={this.handleRadioChange} />
                   <label class="form-check-label" for="ok_to_call">Yes</label>
@@ -351,7 +351,7 @@ class BoxRequestForm extends React.Component {
             </div>
             <div class="col-6"> 
               <div class="row">
-                <label class="following-question">Okay to text?*</label>
+                <label class="following-question">Okay to text?</label>
                 <div class="form-check form-check-inline">
                   <input class="form-check-input" type="radio" name="ok_to_text" id="ok_to_text_true" onChange={this.handleRadioChange} />
                   <label class="form-check-label" for="ok_to_text_true">Yes</label>


### PR DESCRIPTION
Resolves #157  

### Description
Edit logic in app/javascript/src/components/box-request-form/BoxRequestForm.js so that an error is only displayed if a user inputs a phone number and DOESN'T choose options for ok_to_text and ok_to_call. User can submit with no phone number and no options for ok_to_text/call.

Removed asterisks denoting "required" from okay_to_text and okay_to_call.

### Type of change

* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

I have not written tests for this, just tested via Rails server.

### Screenshots
Attempted submission with no phone number entered:
![image](https://user-images.githubusercontent.com/37967627/63230958-9fd7cb00-c1e2-11e9-8b92-16f5a46c6f66.png)

Submission w/ phone number but no radio buttons checked:
![image](https://user-images.githubusercontent.com/37967627/63230968-bda53000-c1e2-11e9-8a35-15808b5b6ea5.png)
