### PR TITLE
Box request form- pagination & progress bar

### DIFF
--- a/app/javascript/src/components/box-request-form/BoxRequestForm.js
+++ b/app/javascript/src/components/box-request-form/BoxRequestForm.js
@@ -1,6 +1,8 @@
 import React, { useState } from 'react'
 import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
+import { Progress } from 'react-sweet-progress';
+import 'react-sweet-progress/lib/style.css';
 
 import TextInput from './text-input'
 import './BoxRequestForm.scss'
@@ -11,6 +13,7 @@ class BoxRequestForm extends React.Component {
     this.state = {
       abuseTypeOptions: ["Emotional", "Physical", "Sexual", "All of the Above"],
       attemptedSubmit: false,
+      step: 0,
       boxRequest: {
         first_name: '',
         last_name: '',
@@ -41,6 +44,8 @@ class BoxRequestForm extends React.Component {
     this.handleRadioChange = this.handleRadioChange.bind(this);
     this.handleCheckBoxChange = this.handleCheckBoxChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
+    this.handlePaginatePrevious = this.handlePaginatePrevious.bind(this);
+    this.handlePaginateForward = this.handlePaginateForward.bind(this);
   }
 
   handleChange(event) {
@@ -127,6 +132,18 @@ class BoxRequestForm extends React.Component {
     return requiredFields.includes(null) || requiredFields.includes('') || abuse_types.length === 0;
   }
 
+  handlePaginatePrevious() {
+    if (this.state.step > 0) {
+      return this.setState({step: this.state.step - 1});
+    }
+  }
+
+  handlePaginateForward() {
+    if (this.state.step < 2) {
+      return this.setState({step: this.state.step + 1});
+    }
+  }
+
   renderRequiredAlert() {
     return (
       <div class="row alert alert-danger required-field" role="alert">
@@ -146,111 +163,112 @@ class BoxRequestForm extends React.Component {
   renderAbuseTypes() {
     const abuseTypes = this.state.abuseTypeOptions.map((type) =>
       <div class="row form-check">
-        <input class="form-check-input" type="checkbox" value={type} id="abuse_types" onChange={this.handleCheckBoxChange} />
+        <input class="form-check-input" type="checkbox" value={type} id="abuse_types" onChange={this.handleCheckBoxChange} checked={this.state.boxRequest.abuse_types.includes(type)} />
         <label class="form-check-label" for="abuse_types">{type}</label>
       </div>
     );
 
     return abuseTypes;
   }
-  render() {
+
+  renderTopSection() {
     const { boxRequest } = this.state;
-
     return (
-      <div class="box-request-container">
-        <div class="box-info">If you are interested in receiving a survivor box, please fill out this quick form below.
-          The more information you provide us with, the better we can help you.
-          All information provided is 100% confidential and only seen by the leaders of our team.
-          The return rate of our survivor boxes is 2-3 weeks due to high demand.
+      <div>
+        <div class="row section-top section-label">Name*</div>
+        { this.state.attemptedSubmit && (boxRequest.first_name == '' || boxRequest.last_name == '') ? this.renderRequiredAlert() : null }
+        <div class="row">
+          <div class="col-md">
+            <input type="text" class="row form-control" name="first_name" value={boxRequest.first_name} onChange={this.handleChange} />
+            <label class="row sub-text">First Name</label>
+          </div>
+          <div class="col-md">
+            <input type="text" class="row form-control" name="last_name" value={boxRequest.last_name} onChange={this.handleChange} />
+            <label class="row sub-text">Last Name</label>
+          </div>
         </div>
-        <form onSubmit={this.handleSubmit}>
-          <div class="row section-top section-label">Name*</div>
-          { this.state.attemptedSubmit && (boxRequest.first_name == '' || boxRequest.last_name == '') ? this.renderRequiredAlert() : null }
-          <div class="row">
-            <div class="col-md">
-              <input type="text" class="row form-control" name="first_name" value={boxRequest.first_name} onChange={this.handleChange} />
-              <label class="row sub-text">First Name</label>
-            </div>
-            <div class="col-md">
-              <input type="text" class="row form-control" name="last_name" value={boxRequest.last_name} onChange={this.handleChange} />
-              <label class="row sub-text">Last Name</label>
-            </div>
+        <div class="row section-top">
+          <label class="section-label">Email Address*</label>
+          <input type="text" class="form-control" name="email" value={boxRequest.email} onChange={this.handleChange} />
+        </div>
+        { this.state.attemptedSubmit && boxRequest.email == '' ? this.renderRequiredAlert() : null }
+        <div class="row">
+          <label class="following-question">Okay to email?*</label>
+          <div class="form-check form-check-inline">
+            <input class="form-check-input" type="radio" name="ok_to_email" id="ok_to_email_true" onChange={this.handleRadioChange} checked={boxRequest.ok_to_email} />
+            <label class="form-check-label" for="ok_to_email">Yes</label>
           </div>
-          <div class="row section-top">
-            <label class="section-label">Email Address*</label>
-            <input type="text" class="form-control" name="email" value={boxRequest.email} onChange={this.handleChange} />
+          <div class="form-check form-check-inline">
+            <input class="form-check-input" type="radio" name="ok_to_email" id="ok_to_email_false" onChange={this.handleRadioChange} checked={boxRequest.ok_to_email === false}/>
+            <label class="form-check-label" for="ok_to_email_false">No</label>
           </div>
-          { this.state.attemptedSubmit && boxRequest.email == '' ? this.renderRequiredAlert() : null }
-          <div class="row">
-            <label class="following-question">Okay to email?*</label>
-            <div class="form-check form-check-inline">
-              <input class="form-check-input" type="radio" name="ok_to_email" id="ok_to_email_true" onChange={this.handleRadioChange} />
-              <label class="form-check-label" for="ok_to_email">Yes</label>
-            </div>
-            <div class="form-check form-check-inline">
-              <input class="form-check-input" type="radio" name="ok_to_email" id="ok_to_email_false" onChange={this.handleRadioChange} />
-              <label class="form-check-label" for="ok_to_email_false">No</label>
-            </div>
-          </div>
-          { this.state.attemptedSubmit && boxRequest.ok_to_email == null ? this.renderRequiredAlert() : null }
+        </div>
+        { this.state.attemptedSubmit && boxRequest.ok_to_email == null ? this.renderRequiredAlert() : null }
 
-          <label class="row section-top">Type(s) of abuse you have faced*</label>
-          { this.state.attemptedSubmit && boxRequest.abuse_types.length === 0 ? this.renderRequiredAlert() : null }
-          { this.renderAbuseTypes() }
+        <label class="row section-top">Type(s) of abuse you have faced*</label>
+        { this.state.attemptedSubmit && boxRequest.abuse_types.length === 0 ? this.renderRequiredAlert() : null }
+        { this.renderAbuseTypes() }
 
-          <div class="row section-top" >
-            <label>Briefly describe your current situation. Is the abuse current? Do you live with your abuser? Do you have kids affected by the abuse? *</label>
-            <textarea type="text" class="form-control" name="question_re_current_situation" value={boxRequest.question_re_current_situation} onChange={this.handleChange} />
-          </div>
-          { this.state.attemptedSubmit && boxRequest.question_re_current_situation == '' ? this.renderRequiredAlert() : null }
+        <div class="row section-top" >
+          <label>Briefly describe your current situation. Is the abuse current? Do you live with your abuser? Do you have kids affected by the abuse?*</label>
+          <textarea type="text" class="form-control" name="question_re_current_situation" value={boxRequest.question_re_current_situation} onChange={this.handleChange} />
+        </div>
+        { this.state.attemptedSubmit && boxRequest.question_re_current_situation == '' ? this.renderRequiredAlert() : null }
 
-          <div class="row section-top">
-            <label>How did this abuse affect your life?*</label>
-            <textarea type="text" class="form-control" name="question_re_affect" value={boxRequest.question_re_affect} onChange={this.handleChange} />
-          </div>
-          { this.state.attemptedSubmit && boxRequest.question_re_affect == '' ? this.renderRequiredAlert() : null }
+        <div class="row section-top">
+          <label>How did this abuse affect your life?*</label>
+          <textarea type="text" class="form-control" name="question_re_affect" value={boxRequest.question_re_affect} onChange={this.handleChange} />
+        </div>
+        { this.state.attemptedSubmit && boxRequest.question_re_affect == '' ? this.renderRequiredAlert() : null }
+      </div>
+    );
+  }
 
-          <label class="row section-top">Do you feel safe now?*</label>
-          { this.state.attemptedSubmit && boxRequest.is_safe == null ? this.renderRequiredAlert() : null }
-          <div class="row">
-            <div class="custom-control custom-radio custom-control-inline">
-              <input type="radio" id="is_safe_true" name="is_safe" class="custom-control-input" onChange={this.handleRadioChange}/>
-              <label class="custom-control-label radio-box" for="is_safe_true">Yes</label>
-            </div>
+  renderMiddleSection() {
+    const { boxRequest } = this.state;
+    return (
+      <div>
+        <label class="row section-top">Do you feel safe now?*</label>
+        { this.state.attemptedSubmit && boxRequest.is_safe == null ? this.renderRequiredAlert() : null }
+        <div class="row">
+          <div class="custom-control custom-radio custom-control-inline">
+            <input type="radio" id="is_safe_true" name="is_safe" class="custom-control-input" onChange={this.handleRadioChange} checked={boxRequest.is_safe}/>
+            <label class="custom-control-label radio-box" for="is_safe_true">Yes</label>
           </div>
-          <div class="row">
-            <div class="custom-control custom-radio custom-control-inline">
-              <input type="radio" id="is_safe_false" name="is_safe" class="custom-control-input" onChange={this.handleRadioChange}/>
-              <label class="custom-control-label radio-box" for="is_safe_false">No</label>
-            </div>
+        </div>
+        <div class="row">
+          <div class="custom-control custom-radio custom-control-inline">
+            <input type="radio" id="is_safe_false" name="is_safe" class="custom-control-input" onChange={this.handleRadioChange} checked={boxRequest.is_safe === false}/>
+            <label class="custom-control-label radio-box" for="is_safe_false">No</label>
           </div>
+        </div>
 
-          <label class="row section-top">Are you interested in learning about free counseling services?*</label>
-          { this.state.attemptedSubmit && boxRequest.is_interested_in_counseling_services == null ? this.renderRequiredAlert() : null }
-          <div class="row">
-            <div class="custom-control custom-radio custom-control-inline">
-              <input type="radio" id="is_interested_in_counseling_services_true" name="is_interested_in_counseling_services" class="custom-control-input" onChange={this.handleRadioChange} />
-              <label class="custom-control-label radio-box" for="is_interested_in_counseling_services_true">Yes</label>
-            </div>
+        <label class="row section-top">Are you interested in learning about free counseling services?*</label>
+        { this.state.attemptedSubmit && boxRequest.is_interested_in_counseling_services == null ? this.renderRequiredAlert() : null }
+        <div class="row">
+          <div class="custom-control custom-radio custom-control-inline">
+            <input type="radio" id="is_interested_in_counseling_services_true" name="is_interested_in_counseling_services" class="custom-control-input" onChange={this.handleRadioChange} checked={boxRequest.is_interested_in_counseling_services} />
+            <label class="custom-control-label radio-box" for="is_interested_in_counseling_services_true">Yes</label>
           </div>
-          <div class="row">
-            <div class="custom-control custom-radio custom-control-inline">
-              <input type="radio" id="is_interested_in_counseling_services_false" name="is_interested_in_counseling_services" class="custom-control-input" onChange={this.handleRadioChange} />
-              <label class="custom-control-label radio-box" for="is_interested_in_counseling_services_false">No</label>
-            </div>
+        </div>
+        <div class="row">
+          <div class="custom-control custom-radio custom-control-inline">
+            <input type="radio" id="is_interested_in_counseling_services_false" name="is_interested_in_counseling_services" class="custom-control-input" onChange={this.handleRadioChange} checked={boxRequest.is_interested_in_counseling_services === false}/>
+            <label class="custom-control-label radio-box" for="is_interested_in_counseling_services_false">No</label>
           </div>
+        </div>
 
-          <label class="row section-top">Are you interested in learning about free health services?*</label>
+        <label class="row section-top">Are you interested in learning about free health services?*</label>
           { this.state.attemptedSubmit && boxRequest.is_interested_in_health_services == null ? this.renderRequiredAlert() : null }
           <div class="row">
             <div class="custom-control custom-radio custom-control-inline">
-              <input type="radio" id="is_interested_in_health_services_true" name="is_interested_in_health_services" class="custom-control-input" onChange={this.handleRadioChange} />
+              <input type="radio" id="is_interested_in_health_services_true" name="is_interested_in_health_services" class="custom-control-input" onChange={this.handleRadioChange} checked={boxRequest.is_interested_in_health_services} />
               <label class="custom-control-label radio-box" for="is_interested_in_health_services_true">Yes</label>
             </div>
           </div>
           <div class="row">
             <div class="custom-control custom-radio custom-control-inline">
-              <input type="radio" id="is_interested_in_health_services_false" name="is_interested_in_health_services" class="custom-control-input" onChange={this.handleRadioChange} />
+              <input type="radio" id="is_interested_in_health_services_false" name="is_interested_in_health_services" class="custom-control-input" onChange={this.handleRadioChange} checked={boxRequest.is_interested_in_health_services === false} />
               <label class="custom-control-label radio-box" for="is_interested_in_health_services_false">No</label>
             </div>
           </div>
@@ -259,13 +277,13 @@ class BoxRequestForm extends React.Component {
           { this.state.attemptedSubmit && boxRequest.is_underage == null ? this.renderRequiredAlert() : null }
           <div class="row">
             <div class="custom-control custom-radio custom-control-inline">
-              <input type="radio" id="is_underage_true" name="is_underage" class="custom-control-input" onChange={this.handleRadioChange} />
+              <input type="radio" id="is_underage_true" name="is_underage" class="custom-control-input" onChange={this.handleRadioChange} checked={boxRequest.is_underage} />
               <label class="custom-control-label radio-box" for="is_underage_true">0-12 years old</label>
             </div>
           </div>
           <div class="row">
             <div class="custom-control custom-radio custom-control-inline">
-              <input type="radio" id="is_underage_false" name="is_underage" class="custom-control-input" onChange={this.handleRadioChange} />
+              <input type="radio" id="is_underage_false" name="is_underage" class="custom-control-input" onChange={this.handleRadioChange} checked={boxRequest.is_underage === false}/>
               <label class="custom-control-label radio-box" for="is_underage_false">13+ years old</label>
             </div>
           </div>
@@ -276,102 +294,158 @@ class BoxRequestForm extends React.Component {
             <input type="text" class="form-control" name="question_re_referral_source" value={boxRequest.question_re_referral_source} onChange={this.handleChange} />
           </div>
           { this.state.attemptedSubmit && boxRequest.question_re_referral_source == '' ? this.renderRequiredAlert() : null }
+      </div>
+    );
+  }
 
-          <div class="row section-top section-label">Address*</div>
-          { this.state.attemptedSubmit && (boxRequest.street_address === '' || boxRequest.city === '' || boxRequest.state === '' || boxRequest.zip === '') ? this.renderRequiredAlert() : null }
-          <div class="row sub-text">
-            <input type="text" class="form-control" name="street_address" value={boxRequest.street_address} onChange={this.handleChange} />
-            <label>Address 1</label>
+  renderFinalSection() {
+    const { boxRequest } = this.state;
+    return (
+      <div>
+        <div class="row section-top section-label">Address*</div>
+        { this.state.attemptedSubmit && (boxRequest.street_address === '' || boxRequest.city === '' || boxRequest.state === '' || boxRequest.zip === '') ? this.renderRequiredAlert() : null }
+        <div class="row sub-text">
+          <input type="text" class="form-control" name="street_address" value={boxRequest.street_address} onChange={this.handleChange} />
+          <label>Address 1</label>
+        </div>
+        <div class="row">
+          <div class="col-9">
+            <div class="row sub-text">
+              <input type="text" class="form-control" name="city" value={boxRequest.city} onChange={this.handleChange} />
+            </div>
+            <label><div class="row sub-text">City</div></label>
           </div>
-          <div class="row">
-            <div class="col-9">
-              <div class="row sub-text">
-                <input type="text" class="form-control" name="city" value={boxRequest.city} onChange={this.handleChange} />
-              </div>
-              <label>
-                <div class="row sub-text">City</div>
-              </label>
+          <div class="col-3">
+            <div class="row sub-text">
+              <input type="text" class="form-control" name="state" value={boxRequest.state} onChange={this.handleChange} />
             </div>
-            <div class="col-3">
-              <div class="row sub-text">
-                <input type="text" class="form-control" name="state" value={boxRequest.state} onChange={this.handleChange} />
-              </div>
-              <label>
-                <div class="row sub-text">State</div>
-              </label>
-            </div>
+            <label><div class="row sub-text">State</div></label>
           </div>
-          <div class="row">
-            <div class="col-md">
-              <div class="row">
-                <input type="text" class="form-control" name="zip" value={boxRequest.zip} onChange={this.handleChange} />
-              </div>
-              <label>
-                <div class="row sub-text">Zip Code</div>
-              </label>
+        </div>
+        <div class="row">
+          <div class="col-md">
+            <div class="row">
+              <input type="text" class="form-control" name="zip" value={boxRequest.zip} onChange={this.handleChange} />
             </div>
-            <div class="col-md">
-              <div class="row">
-                <input type="text" class="form-control" name="county" value={boxRequest.county} onChange={this.handleChange} />
-              </div>
-              <label>
-                <div class="row sub-text">County</div>
-              </label>
-            </div>
+            <label><div class="row sub-text">Zip Code</div></label>
           </div>
-          <div class="row">
-            <label class="following-question">Okay to mail?*</label>
-            <div class="form-check form-check-inline">
-              <input class="form-check-input" type="radio" name="ok_to_mail" id="ok_to_mail_true" onChange={this.handleRadioChange} />
-              <label class="form-check-label" for="ok_to_mail">Yes</label>
+          <div class="col-md">
+            <div class="row">
+              <input type="text" class="form-control" name="county" value={boxRequest.county} onChange={this.handleChange} />
             </div>
-            <div class="form-check form-check-inline">
-              <input class="form-check-input" type="radio" name="ok_to_mail" id="ok_to_mail_false" onChange={this.handleRadioChange} />
-              <label class="form-check-label" for="ok_to_mail_false">No</label>
-            </div>
+            <label><div class="row sub-text">County</div></label>
           </div>
-          { this.state.attemptedSubmit && boxRequest.ok_to_mail == null ? this.renderRequiredAlert() : null }
+        </div>
+        <div class="row">
+          <label class="following-question">Okay to mail?*</label>
+          <div class="form-check form-check-inline">
+            <input class="form-check-input" type="radio" name="ok_to_mail" id="ok_to_mail_true" onChange={this.handleRadioChange} checked={boxRequest.ok_to_mail} />
+            <label class="form-check-label" for="ok_to_mail">Yes</label>
+          </div>
+          <div class="form-check form-check-inline">
+            <input class="form-check-input" type="radio" name="ok_to_mail" id="ok_to_mail_false" onChange={this.handleRadioChange} checked={boxRequest.ok_to_mail === false} />
+            <label class="form-check-label" for="ok_to_mail_false">No</label>
+          </div>
+        </div>
+        { this.state.attemptedSubmit && boxRequest.ok_to_mail == null ? this.renderRequiredAlert() : null }
 
-          <div class="row section-top">
-            <label class="section-label">Phone</label>
-            <input type="text" class="form-control" name="phone" value={boxRequest.phone} onChange={this.handleChange} />
-            <div class="col-6"> 
-              <div class="row">
-                <label class="following-question">Okay to call?</label>
-                <div class="form-check form-check-inline">
-                  <input class="form-check-input" type="radio" name="ok_to_call" id="ok_to_call_true" onChange={this.handleRadioChange} />
-                  <label class="form-check-label" for="ok_to_call">Yes</label>
-                </div>
-                
-                <div class="form-check form-check-inline">
-                  <input class="form-check-input" type="radio" name="ok_to_call" id="ok_to_call_false" onChange={this.handleRadioChange} />
-                  <label class="form-check-label" for="ok_to_call_false">No</label>
-                </div>
+        <div class="row section-top">
+          <label class="section-label">Phone</label>
+          <input type="text" class="form-control" name="phone" value={boxRequest.phone} onChange={this.handleChange} />
+          <div class="col-6"> 
+            <div class="row">
+              <label class="following-question">Okay to call?*</label>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="ok_to_call" id="ok_to_call_true" onChange={this.handleRadioChange} checked={boxRequest.ok_to_call}/>
+                <label class="form-check-label" for="ok_to_call">Yes</label>
               </div>
-            </div>
-            <div class="col-6"> 
-              <div class="row">
-                <label class="following-question">Okay to text?</label>
-                <div class="form-check form-check-inline">
-                  <input class="form-check-input" type="radio" name="ok_to_text" id="ok_to_text_true" onChange={this.handleRadioChange} />
-                  <label class="form-check-label" for="ok_to_text_true">Yes</label>
-                </div>
-                <div class="form-check form-check-inline">
-                  <input class="form-check-input" type="radio" name="ok_to_text" id="ok_to_text_false" onChange={this.handleRadioChange} />
-                  <label class="form-check-label" for="ok_to_text_false">No</label>
-                </div>
+              
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="ok_to_call" id="ok_to_call_false" onChange={this.handleRadioChange} checked={boxRequest.ok_to_call === false}/>
+                <label class="form-check-label" for="ok_to_call_false">No</label>
               </div>
             </div>
           </div>
-          { this.state.attemptedSubmit && boxRequest.phone != '' && (boxRequest.ok_to_text == null || boxRequest.ok_to_call == null) ? this.renderRequiredAlert() : null }
-
-          <div class="row section-top">
-            <label>Are you requesting this box for someone else? If so, please briefly explain. </label>
-            <input type="text" class="form-control" name="question_re_if_not_self_completed" value={boxRequest.question_re_if_not_self_completed} onChange={this.handleChange} />
+          <div class="col-6"> 
+            <div class="row">
+              <label class="following-question">Okay to text?*</label>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="ok_to_text" id="ok_to_text_true" onChange={this.handleRadioChange} checked={boxRequest.ok_to_text} />
+                <label class="form-check-label" for="ok_to_text_true">Yes</label>
+              </div>
+              <div class="form-check form-check-inline">
+                <input class="form-check-input" type="radio" name="ok_to_text" id="ok_to_text_false" onChange={this.handleRadioChange} checked={boxRequest.ok_to_text === false} />
+                <label class="form-check-label" for="ok_to_text_false">No</label>
+              </div>
+            </div>
           </div>
+        </div>
+        { this.state.attemptedSubmit && boxRequest.phone != '' && (boxRequest.ok_to_text == null || boxRequest.ok_to_call == null) ? this.renderRequiredAlert() : null }
 
+        <div class="row section-top">
+          <label>Are you requesting this box for someone else? If so, please briefly explain. </label>
+          <input type="text" class="form-control" name="question_re_if_not_self_completed" value={boxRequest.question_re_if_not_self_completed} onChange={this.handleChange} />
+        </div>
+      </div>
+    );
+  }
+
+  renderProgressBar() {
+    const { first_name, last_name, email, street_address, city, state, zip, ok_to_mail, ok_to_call, ok_to_text, ok_to_email, question_re_affect, 
+      question_re_referral_source, question_re_current_situation, is_safe, is_interested_in_counseling_services, is_interested_in_health_services, is_underage, abuse_types } = this.state.boxRequest;
+
+    const completedFields = [first_name, last_name, email, street_address, city, state, zip, question_re_affect,
+      question_re_referral_source, question_re_current_situation, is_safe, ok_to_mail, ok_to_call, ok_to_text,
+      ok_to_email, is_interested_in_counseling_services, is_interested_in_health_services, is_underage].filter(n => n === false || n);
+
+    const percentageComplete = parseInt(completedFields.length / 17 * 100);
+
+    return (
+      <Progress percent={percentageComplete}  />
+    );
+  }
+
+  renderPaginationAndProgressBar() {
+    const currentStep = this.state.step;
+    return (
+      <div>
+        <nav class="form-pagination row">
+          <ul class="pagination">
+            <li class={currentStep == 0 ? "page-item disabled" : "page-item"} onClick={this.handlePaginatePrevious}>
+              <span class="page-link">Previous</span>
+            </li>
+            <li class={currentStep == 0 ? "page-item active" : "page-item"} onClick={() => this.setState({step: 0})}><a class="page-link">1</a></li>
+            <li class={currentStep == 1 ? "page-item active" : "page-item"} onClick={() => this.setState({step: 1})}>
+              <a class="page-link"> 2 </a>
+            </li>
+            <li class={currentStep == 2 ? "page-item active" : "page-item"} onClick={() => this.setState({step: 2})}><a class="page-link">3</a></li>
+            <li class={currentStep == 2 ? "page-item disabled" : "page-item"} onClick={this.handlePaginateForward}>
+              <span class="page-link">Next</span>
+            </li>
+          </ul>
+        </nav>
+      { this.renderProgressBar() }
+      </div>
+    );
+  }
+
+  render() {
+    const { boxRequest } = this.state;
+
+    return (
+      <div class="box-request-container">
+        <div class="box-info">If you are interested in receiving a survivor box, please fill out this quick form below.
+          The more information you provide us with, the better we can help you.
+          All information provided is 100% confidential and only seen by the leaders of our team.
+          The return rate of our survivor boxes is 2-3 weeks due to high demand.
+        </div>
+        <form onSubmit={this.handleSubmit} style={{'border-top': '2px dotted gray'}}>
+          { this.state.step === 0 && this.renderTopSection() }
+          { this.state.step === 1 && this.renderMiddleSection() }
+          { this.state.step === 2 && this.renderFinalSection() }
+          { this.renderPaginationAndProgressBar() }
           { this.state.attemptedSubmit && this.missingRequiredFields() ? this.renderMissingFieldsAlert() : null }
-            <input type="submit" value="SUBMIT - SEND ME A SURVIVOR BOX" />
+          <input type="submit" value="SUBMIT - SEND ME A SURVIVOR BOX" class={this.missingRequiredFields() ? "gray-submit" : null}/>
         </form>
       </div>
     );

--- a/app/javascript/src/components/box-request-form/BoxRequestForm.scss
+++ b/app/javascript/src/components/box-request-form/BoxRequestForm.scss
@@ -37,6 +37,7 @@ textarea[type=text] {
 .box-request-container {
   padding-left: 5%;
   padding-right: 5%;
+  margin-bottom: 5%;
 }
 
 .custom-control-label::before,
@@ -57,6 +58,19 @@ textarea[type=text] {
 .form-check-input,
 .form-check-label {
     font-size: 12px;
+}
+
+.form-pagination {
+  margin-left: 30%;
+  margin-top: 20px;
+}
+
+.gray-submit {
+  background-color: gray !important;
+}
+
+.page-link {
+  cursor: pointer;
 }
 
 .radio-box {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "popper.js": "^1.15.0",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "react-dom": "^16.8.6",
+    "react-sweet-progress": "^1.1.2"
   },
   "devDependencies": {
     "webpack-dev-server": "^3.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1674,6 +1674,11 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+classnames@^2.2.5:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
 cliui@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
@@ -5758,6 +5763,13 @@ react-is@^16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
+react-sweet-progress@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/react-sweet-progress/-/react-sweet-progress-1.1.2.tgz#b27c6baa7c08a12cf0896565431ba477af249892"
+  integrity sha512-FUfiKpox5LJ9YTeK/HsaLp/oOsuxWBJQir6oAYKLY5nsa2pb04PtxzddSy6Y1fn8osaILpXIcItJRQYnHp42CA==
+  dependencies:
+    classnames "^2.2.5"
 
 react@^16.8.6:
   version "16.8.6"


### PR DESCRIPTION
Per issue https://github.com/rubyforgood/voices-of-consent/issues/152, adds pagination-style experience on the front-end, along with a status bar to show how much of the form remains. 

Continued tweaking of the styling may likely be desired; here's a screenshot of how it currently looks:

(In the PR I also added handling so that the submit button is grayed out until all of the required fields have been entered for clarity)

<img width="1060" alt="Screen Shot 2019-08-20 at 8 49 30 PM" src="https://user-images.githubusercontent.com/11711662/63394084-119f4880-c38c-11e9-89b4-d36d5a5dcce4.png">
