### PR TITLE
Lay groundwork for BoxRequests index to be filterable by new aasm states

### DIFF
--- a/app/controllers/box_requests_controller.rb
+++ b/app/controllers/box_requests_controller.rb
@@ -6,8 +6,9 @@ class BoxRequestsController < ApplicationController
   def index
     @box_requests = BoxRequest.all
 
-    if (sort_attr = params[:sort_by])
-      @box_requests = @box_requests.order(sort_attr)
+    if params[:filter_by].present?
+      (filter_attr = params[:filter_by])
+      @box_requests = @box_requests.public_send(filter_attr)
     end
   end
 

--- a/app/models/box_request.rb
+++ b/app/models/box_request.rb
@@ -16,7 +16,13 @@ class BoxRequest < ApplicationRecord
   delegate :designer_name, :assembler_name, :shipper_name, :followup_sent?, to: :box, allow_nil: true
   delegate :name, to: :reviewed_by, prefix: :reviewer, allow_nil: true
 
-
+  scope :requested, ->(){ where(reviewed_by_id: nil) }
+  scope :designed, ->(){ joins(:box).where("boxes.aasm_state = ?", "desgined") }
+  scope :design_in_progress, ->(){ joins(:box).where("boxes.aasm_state = ?", "design_in_progress") }
+  scope :assembly_in_progress, ->(){ joins(:box).where("boxes.aasm_state = ?", "assembly_in_progress") }
+  scope :assembled, ->(){ joins(:box).where("boxes.aasm_state = ?", "assembled") }
+  scope :shipping_in_progress, ->(){ joins(:box).where("boxes.aasm_state = ?", "shipping_in_progress") }
+  scope :shipped, ->(){ joins(:box).where("boxes.aasm_state = ?", "shipped") }
 
   aasm do
 

--- a/app/views/box_requests/index.html.erb
+++ b/app/views/box_requests/index.html.erb
@@ -2,18 +2,28 @@
 
 <h1>Box Requests</h1>
 
-<form>
-  <%= select_tag :sort_by, {
-    review: "Review Stage",
-    design: "Design Stage",
-    packing: "Packing Stage",
-    shipping: "Shipping Stage",
-  }.map { |attribute, label|
-    "<option value=#{attribute.to_s.inspect}>#{label}</option>"
-  }.join.html_safe %>
-
-  <button>Sort this list</button>
-</form>
+<%= simple_form_for :box_requests,
+                    html: { class: 'form-inline'},
+                    url: box_requests_path,
+                    method: :get do |f| %>
+  <%= select_tag     "filter_by",
+                       options_for_select(
+                           [:requested,
+                            :review_in_progress,
+                            :reviewed,
+                            :design_in_progress,
+                            :designed,
+                            :assembly_in_progress,
+                            :assembled,
+                            :shipping_in_progress,
+                            :shipped,
+                           ],
+                           selected: params[:filter_by]),
+                       include_blank: "-- Filter options --",
+                       placeholder: "",
+                       class: "form-control" %>
+  <%= f.button :submit, "Filter", class: "form-group btn btn-success button", name: nil %>
+<% end %>
 
 <table class="table box-requests-table">
   <thead>


### PR DESCRIPTION
Fix #160 

- Add hard-coded list of dropdown states (they'll need to be prettier, and possibly dynamically generated instead)
- Add relevant scopes (bc BoxRequest doesn't hold all aasm states -- most are on the associated Box)
- Add filter to BoxRequestsController index action to public_send filter names