### PR TITLE
Add missing association for User has_many box_items_as_researcher

### DIFF
--- a/app/models/box_item.rb
+++ b/app/models/box_item.rb
@@ -1,8 +1,9 @@
 class BoxItem < ApplicationRecord
   belongs_to :box
   belongs_to :inventory_type
-  belongs_to :created_by, optional: true, class_name: "User", foreign_key: :created_by_id, inverse_of: :box_items_as_creator
-  belongs_to :updated_by, optional: true, class_name: "User", foreign_key: :updated_by_id, inverse_of: :box_items_as_updater
+  belongs_to :researched_by, optional: true, class_name: "User", foreign_key: :created_by_id, inverse_of: :box_items_as_researcher
+  belongs_to :created_by,    optional: true, class_name: "User", foreign_key: :created_by_id, inverse_of: :box_items_as_creator
+  belongs_to :updated_by,    optional: true, class_name: "User", foreign_key: :updated_by_id, inverse_of: :box_items_as_updater
 
   has_many_attached :file_uploads
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord
   has_many :user_permissions
 
   has_many :box_items_as_creator, class_name: "BoxItem", foreign_key: :created_by_id, inverse_of: :created_by, dependent: :restrict_with_error
+  has_many :box_items_as_researcher, class_name: "BoxItem", foreign_key: :created_by_id, inverse_of: :created_by, dependent: :restrict_with_error
   has_many :box_items_as_updater, class_name: "BoxItem", foreign_key: :updated_by_id, inverse_of: :updated_by, dependent: :restrict_with_error
   has_many :box_requests_as_reviewer, class_name: "BoxRequest", foreign_key: :reviewed_by_id, inverse_of: :reviewed_by, dependent: :restrict_with_error
   has_many :boxes_as_designer, class_name: "Box", foreign_key: :designed_by_id, inverse_of: :designed_by, dependent: :restrict_with_error


### PR DESCRIPTION
Fix #169 
- Database has the foreign key, but model associations hadn't been added
- Some of the BoxItems require research/compilation, and we want to track who did that work