### PR TITLE
155 message log index styling

### DIFF
--- a/app/views/message_logs/index.html.erb
+++ b/app/views/message_logs/index.html.erb
@@ -2,37 +2,38 @@
 
 <h1>Message Logs</h1>
 <div class="table-responsive">
-  <table class="table">
-    <thead>
-      <tr>
-        <th scope="col">messageable type</th>
-        <th scope="col">messageable</th>
-        <th scope="col">Content</th>
-        <th scope="col">Delivery type</th>
-        <th scope="col">Delivery status</th>
-        <th scope="col">Sent to</th>
-        <th scope="col">Sent by</th>
-        <th colspan="3"></th>
-      </tr>
-    </thead>
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">messageable type</th>
+      <th scope="col">messageable</th>
+      <th scope="col">Content</th>
+      <th scope="col">Delivery type</th>
+      <th scope="col">Delivery status</th>
+      <th scope="col">Sent to</th>
+      <th scope="col">Sent by</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
 
-    <tbody>
-      <% @message_logs.each do |message_log| %>
-        <tr>
-          <th scope="row"><%= message_log.message_type %></th>
-          <td><%= message_log.id %></td>
-          <td><%= message_log.content %></td>
-          <td><%= message_log.delivery_type %></td>
-          <td><%= message_log.delivery_status %></td>
-          <td><%= message_log.sent_to.email %></td>
-          <td><%= message_log.sent_by.email %></td>
-          <td><%= link_to 'Show', message_log %></td>
-          <td><%= link_to 'Edit', edit_message_log_path(message_log) %></td>
-          <td><%= link_to 'Destroy', message_log, method: :delete, data: { confirm: 'Are you sure?' } %></td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+  <tbody>
+    <% @message_logs.each do |message_log| %>
+      <tr>
+        <th scope="row"><%= message_log.message_type %></th>
+        <td><%= message_log.id %></td>
+        <%# Strip HTML tags and hard carriage returns since content returns as a long HTML string%>
+        <td><%= strip_tags(message_log.content).gsub(/=0D/, "") %></td>
+        <td><%= message_log.delivery_type %></td>
+        <td><%= message_log.delivery_status %></td>
+        <td><%= message_log.sent_to.email %></td>
+        <td><%= message_log.sent_by.email %></td>
+        <td><%= link_to 'Show', message_log %></td>
+        <td><%= link_to 'Edit', edit_message_log_path(message_log) %></td>
+        <td><%= link_to 'Destroy', message_log, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
 </div>
 <br>
 

--- a/app/views/message_logs/index.html.erb
+++ b/app/views/message_logs/index.html.erb
@@ -19,13 +19,13 @@
   <tbody>
     <% @message_logs.each do |message_log| %>
       <tr>
-        <td><%= message_log.messageable_type %></td>
-        <td><%= message_log.messageable.id %></td>
+        <td><%= message_log.message_type %></td>
+        <td><%= message_log.id %></td>
         <td><%= message_log.content %></td>
         <td><%= message_log.delivery_type %></td>
         <td><%= message_log.delivery_status %></td>
-        <td><%= message_log.sent_to.name %></td>
-        <td><%= message_log.sent_by.name %></td>
+        <td><%= message_log.sent_to.email %></td>
+        <td><%= message_log.sent_by.email %></td>
         <td><%= link_to 'Show', message_log %></td>
         <td><%= link_to 'Edit', edit_message_log_path(message_log) %></td>
         <td><%= link_to 'Destroy', message_log, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/message_logs/index.html.erb
+++ b/app/views/message_logs/index.html.erb
@@ -1,39 +1,39 @@
 <p id="notice"><%= notice %></p>
 
 <h1>Message Logs</h1>
-
-<table>
-  <thead>
-    <tr>
-      <th>messageable type</th>
-      <th>messageable</th>
-      <th>Content</th>
-      <th>Delivery type</th>
-      <th>Delivery status</th>
-      <th>Sent to</th>
-      <th>Sent by</th>
-      <th colspan="3"></th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <% @message_logs.each do |message_log| %>
+<div class="table-responsive">
+  <table class="table">
+    <thead>
       <tr>
-        <td><%= message_log.message_type %></td>
-        <td><%= message_log.id %></td>
-        <td><%= message_log.content %></td>
-        <td><%= message_log.delivery_type %></td>
-        <td><%= message_log.delivery_status %></td>
-        <td><%= message_log.sent_to.email %></td>
-        <td><%= message_log.sent_by.email %></td>
-        <td><%= link_to 'Show', message_log %></td>
-        <td><%= link_to 'Edit', edit_message_log_path(message_log) %></td>
-        <td><%= link_to 'Destroy', message_log, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <th scope="col">messageable type</th>
+        <th scope="col">messageable</th>
+        <th scope="col">Content</th>
+        <th scope="col">Delivery type</th>
+        <th scope="col">Delivery status</th>
+        <th scope="col">Sent to</th>
+        <th scope="col">Sent by</th>
+        <th colspan="3"></th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
 
+    <tbody>
+      <% @message_logs.each do |message_log| %>
+        <tr>
+          <th scope="row"><%= message_log.message_type %></th>
+          <td><%= message_log.id %></td>
+          <td><%= message_log.content %></td>
+          <td><%= message_log.delivery_type %></td>
+          <td><%= message_log.delivery_status %></td>
+          <td><%= message_log.sent_to.email %></td>
+          <td><%= message_log.sent_by.email %></td>
+          <td><%= link_to 'Show', message_log %></td>
+          <td><%= link_to 'Edit', edit_message_log_path(message_log) %></td>
+          <td><%= link_to 'Destroy', message_log, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
 <br>
 
 <%= link_to 'New Message Log', new_message_log_path %>

--- a/app/views/message_logs/index.html.erb
+++ b/app/views/message_logs/index.html.erb
@@ -5,13 +5,13 @@
 <table class="table">
   <thead>
     <tr>
-      <th scope="col">messageable type</th>
-      <th scope="col">messageable</th>
+      <th scope="col">Message Type</th>
+      <th scope="col">Messageable</th>
       <th scope="col">Content</th>
       <th scope="col">Delivery type</th>
       <th scope="col">Delivery status</th>
-      <th scope="col">Sent to</th>
-      <th scope="col">Sent by</th>
+      <th scope="col">Sent to e-mail</th>
+      <th scope="col">Sent by e-mail</th>
       <th colspan="3"></th>
     </tr>
   </thead>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -197,12 +197,9 @@ ActiveRecord::Schema.define(version: 2019_09_02_213913) do
     t.integer "sent_by_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "messageable_type"
-    t.bigint "messageable_id"
     t.string "subject_line"
     t.string "message_channel"
     t.string "message_type"
-    t.index ["messageable_type", "messageable_id"], name: "index_message_logs_on_messageable_type_and_messageable_id"
   end
 
   create_table "purchases", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -197,9 +197,12 @@ ActiveRecord::Schema.define(version: 2019_09_02_213913) do
     t.integer "sent_by_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "messageable_type"
+    t.bigint "messageable_id"
     t.string "subject_line"
     t.string "message_channel"
     t.string "message_type"
+    t.index ["messageable_type", "messageable_id"], name: "index_message_logs_on_messageable_type_and_messageable_id"
   end
 
   create_table "purchases", force: :cascade do |t|


### PR DESCRIPTION
Resolves #155 

### Description

-Add bootstrap styling to message log index
-Basic tag/HTML strip so message_content is more readable

### Type of change

- Styling Update

### How Has This Been Tested?

Only tested in browser. Tests are not passing as they're not updated with messageable_id and messageable_type.

### Screenshots

![image](https://user-images.githubusercontent.com/37967627/66259682-ddd48280-e781-11e9-9804-dd5f00f41f1f.png)

