### PR TITLE
Add email workflow support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@ EMAIL_SERVICE_HOST=localhost
 EMAIL_SERVICE_PORT=1025
 EMAIL_LINK_HOST=localhost:5000
 DEFAULT_FROM_EMAIL="someone@voicesofconsent.org"
+HEROKU_APP_NAME=voices-of-consent
+HEROKU_TEST_DB_URL=[voices-of-consent-test::DATABASE_URL]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,11 @@
 module ApplicationHelper
+  def heroku_link(destination_string)
+    if ENV['RAILS_ENV'] == 'production' && ENV['DATABASE_URL'] == ENV['HEROKU_TEST_DB_URL']
+      "https://voices-of-consent-test.herokuapp.com/#{destination_string}" # 2nd production site, aka staging
+    elsif ENV['RAILS_ENV'] == 'production' && ENV['DATABASE_URL'] != ENV['HEROKU_TEST_DB_URL']
+      "https://#{ENV['HEROKU_APP_NAME']}.herokuapp.com/#{destination_string}"
+    else
+      "/#{destination_string.gsub(/^\//, "")}"
+    end
+  end
 end

--- a/app/mailers/volunteer_mailer.rb
+++ b/app/mailers/volunteer_mailer.rb
@@ -4,8 +4,9 @@ class VolunteerMailer < ApplicationMailer
         mail(to: User.find(@volunteer.user_id).email, subject: 'Welcome to Voices of Consent!')
     end
 
-    def box_request_email(volunteer)
+    def box_request_email(volunteer, box_request_id)
         @volunteer = volunteer
+        @box_request = BoxRequest.find(box_request_id)
         mail(to: User.find(@volunteer.user_id).email, subject: 'A Box Request has been sent')
     end
 

--- a/app/views/box_requests/thanks_anyway.html.erb
+++ b/app/views/box_requests/thanks_anyway.html.erb
@@ -1,0 +1,218 @@
+<link href="https://fonts.googleapis.com/css?family=Roboto:400,400,500,500i,700,700i" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=PT+Sans:400,400,500,500i,700,700i" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css?family=Lora:400,400,500,500i,700,700i" rel="stylesheet"><!--<![endif]-->
+<table cellpadding="0" cellspacing="0" border="0" style="width:100%;margin:0px auto;">
+    <tbody>
+    <tr>
+        <td class="fusionResponsiveCanvas" valign="top" style='width:100%;padding-top:15px;padding-bottom:15px;background-color:rgb(255,198,201);background-image:url("https://ui.icontact.com/assets/themes/spring-flowers/spring_flowers_background.jpg");font-family:"PT Sans", sans-serif;background-position:left top;background-repeat:repeat repeat;'>
+        <table cellpadding="0" cellspacing="0" border="0" data-fusion-class="Preheader" style="width:100%;margin:0px auto;">
+            <tbody>
+            <tr>
+                <td valign="top" style="width:100%;">
+                <table class="fusionResponsiveContent" cellspacing="0" cellpadding="0" border="0" align="center" style="margin:0px auto;width:600px;table-layout:fixed;background-color:transparent;">
+                    <tbody>
+                    <tr>
+                        <td style="background-color:transparent;padding:15px 0px;border:0px none transparent;">
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+        <table cellpadding="0" cellspacing="0" border="0" data-fusion-class="LogoContainer" style="width:100%;margin:0px auto;">
+            <tbody>
+            <tr>
+                <td valign="top" style="width:100%;">
+                <table class="fusionResponsiveContent" cellspacing="0" cellpadding="0" border="0" align="center" style="margin:0px auto;width:600px;table-layout:fixed;background-color:rgb(255,255,255);">
+                    <tbody>
+                    <tr>
+                        <td style="background-color:rgb(255,255,255);padding:0px;border:2px solid rgb(247,164,164);">
+                        <table class="fusionResponsiveContent" cellspacing="0" cellpadding="0" border="0" style="width:100%;table-layout:fixed;">
+                            <tbody>
+                            <tr>
+                                <td valign="top" class="fusionResponsiveColumn" data-fusion-class="" style="width:596px;background-color:transparent;padding:0px;border:0px none transparent;transition:all 0.2s;">
+                                <div data-aqa="block-image" style="overflow:hidden;">
+                                    <table cellpadding="0" cellspacing="0" border="0" style="width:100%;">
+                                    <tbody>
+                                        <tr>
+                                        <td class="null" style="padding:0px;">
+                                            <table align="center" cellpadding="0" cellspacing="0" border="0" style="margin:auto;width:100%;">
+                                            <tbody>
+                                                <tr>
+                                                <td style="border:0px none transparent;">
+                                                    <img src="https://voices-of-consent-static-images.s3.amazonaws.com/voc_logo.jpg" class="fusionResponsiveImage" alt="Voices of Consent image" width="596" height="auto" style="display:block;width:596px;height:auto;margin:auto;background-color:transparent;" title="Voices of Consent image">
+                                                </td>
+                                                </tr>
+                                            </tbody>
+                                            </table>
+                                        </td>
+                                        </tr>
+                                    </tbody>
+                                    </table>
+                                </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+        <table cellpadding="0" cellspacing="0" border="0" data-fusion-class="Main," style="width:100%;margin:0px auto;">
+            <tbody>
+            <tr>
+                <td valign="top" style="width:100%;">
+                <table class="fusionResponsiveContent" cellspacing="0" cellpadding="0" border="0" align="center" style="margin:0px auto;width:600px;table-layout:fixed;background-color:rgb(255,255,255);">
+                    <tbody>
+                    <tr>
+                        <td style="background-color:rgb(255,255,255);padding:20px 8px 20px 7px;border:0px none transparent;">
+                        <table class="fusionResponsiveContent" cellspacing="0" cellpadding="0" border="0" style="width:100%;table-layout:fixed;">
+                            <tbody>
+                            <tr>
+                                <td class="fusionResponsiveColumn" style="mso-line-height-rule:exactly;width:8px;line-height:0;font-size:0px;">
+                                <!--[if !mso]><!--><img src="https://ui.icontact.com/assets/1px.png" class="css-fisw11" width="1" border="0" style="display: block;"><!--<![endif]-->
+                                </td>
+                                <td valign="top" class="fusionResponsiveColumn" data-fusion-class="" style="width:570px;background-color:transparent;padding:0px;border:0px none transparent;transition:all 0.2s;">
+                                <table cellpadding="0" cellspacing="0" style="width:100%;">
+                                    <tbody>
+                                    <tr>
+                                        <td>
+                                        <div data-fusion-class="Headline" style='margin:0px 0px 10px;padding:0px;border:0px none transparent;background-color:transparent;display:block;color:rgb(0,0,0);font-family:"PT Sans", sans-serif;font-size:14px;text-align:left;'>
+                                            <h1 style="text-align:center;color:rgb(45,202,220);font-size:44px;font-family:Lora, serif;margin-top:0px;margin-bottom:0px;">
+                                            <span style="color:rgb(247, 164, 164);">Thanks anyway!</span>
+                                            </h1>
+                                        </div>
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                                </td>
+                                <td class="fusionResponsiveColumn" style="mso-line-height-rule:exactly;width:7px;line-height:0;font-size:0px;">
+                                <!--[if !mso]><!--><img src="https://ui.icontact.com/assets/1px.png" class="css-fisw11" width="1" border="0" style="display: block;"><!--<![endif]-->
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+        <table cellpadding="0" cellspacing="0" border="0" data-fusion-class="HeroContainer" style="width:100%;margin:0px auto;">
+            <tbody>
+            <tr>
+                <td valign="top" style="width:100%;">
+                <table class="fusionResponsiveContent" cellspacing="0" cellpadding="0" border="0" align="center" style="margin:0px auto;width:600px;table-layout:fixed;background-color:rgb(255,255,255);">
+                    <tbody>
+                    <tr>
+                        <td style="background-color:rgb(255,255,255);padding:0px;border:0px none transparent;">
+                        <table class="fusionResponsiveContent" cellspacing="0" cellpadding="0" border="0" style="width:100%;table-layout:fixed;">
+                            <tbody>
+                            <tr>
+                                <td valign="top" class="fusionResponsiveColumn" data-fusion-class="" style="width:600px;background-color:transparent;padding:0px;border:0px none transparent;transition:all 0.2s;">
+                                <div data-aqa="block-image" style="overflow:hidden;">
+                                    <table cellpadding="0" cellspacing="0" border="0" style="width:100%;">
+                                    <tbody>
+                                        <tr>
+                                        <td class="null" style="padding:0px;">
+                                            <table align="center" cellpadding="0" cellspacing="0" border="0" style="margin:auto;">
+                                            <tbody>
+                                                <tr>
+                                                <td style="border:0px none transparent;">
+                                                    <img src="https://staticapp.icpsc.com/icp/resources/mogile/265152/1e6e9b78d5d6485d8dcdb06bd543de76.jpeg" class="fusionResponsiveImage" alt="Voices of Consent image" width="600" height="auto" style="display:block;width:600px;height:auto;margin:auto;background-color:transparent;" title="Voices of Consent image">
+                                                </td>
+                                                </tr>
+                                            </tbody>
+                                            </table>
+                                        </td>
+                                        </tr>
+                                    </tbody>
+                                    </table>
+                                </div>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+        <table cellpadding="0" cellspacing="0" border="0" data-fusion-class="Main,Contrast" style="width:100%;margin:0px auto;">
+            <tbody>
+            <tr>
+                <td valign="top" style="width:100%;">
+                <table class="fusionResponsiveContent" cellspacing="0" cellpadding="0" border="0" align="center" style="margin:0px auto;width:600px;table-layout:fixed;background-color:rgb(240,240,240);">
+                    <tbody>
+                    <tr>
+                        <td style="background-color:rgb(240,240,240);padding:20px 8px 20px 7px;border:0px none transparent;">
+                        <table class="fusionResponsiveContent" cellspacing="0" cellpadding="0" border="0" style="width:100%;table-layout:fixed;">
+                            <tbody>
+                            <tr>
+                                <td class="fusionResponsiveColumn" style="mso-line-height-rule:exactly;width:8px;line-height:0;font-size:0px;">
+                                <!--[if !mso]><!--><img src="https://ui.icontact.com/assets/1px.png" class="css-fisw11" width="1" border="0" style="display: block;"><!--<![endif]-->
+                                </td>
+                                <td valign="top" class="fusionResponsiveColumn" data-fusion-class="" style="width:570px;background-color:transparent;padding:0px;border:0px none transparent;transition:all 0.2s;">
+                                <table cellpadding="0" cellspacing="0" style="width:100%;">
+                                    <tbody>
+                                    <tr>
+                                        <td>
+                                        <div data-fusion-class="Content" style='margin:0px 0px 25px;padding:0px;border:0px none transparent;background-color:transparent;display:block;color:rgb(0,0,0);font-family:"PT Sans", sans-serif;font-size:14px;text-align:left;'>
+                                            <p style="mso-line-height-rule:exactly;text-align:center;line-height:32px;margin-top:0px;margin-bottom:0px;">
+                                            <span style="font-family:Lora, serif;font-size:16px;">We received your decline.</span>
+                                            </p>
+                                            <p class="paragraph-spacing-none" style="mso-line-height-rule:exactly;text-align:center;line-height:32px;margin-top:0px;margin-bottom:0px;">
+                                            <span style="font-family:Lora, serif;font-size:16px;">Thank you for being a Voices of Consent Volunteer!</span>
+                                            </p>
+                                        </div>
+                                        </td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                                </td>
+                                <td class="fusionResponsiveColumn" style="mso-line-height-rule:exactly;width:7px;line-height:0;font-size:0px;">
+                                <!--[if !mso]><!--><img src="https://ui.icontact.com/assets/1px.png" class="css-fisw11" width="1" border="0" style="display: block;"><!--<![endif]-->
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+        <table cellpadding="0" cellspacing="0" border="0" data-fusion-class="Footer,Contrast" style="width:100%;margin:0px auto;">
+            <tbody>
+            <tr>
+                <td valign="top" style="width:100%;">
+                <table class="fusionResponsiveContent" cellspacing="0" cellpadding="0" border="0" align="center" style="margin:0px auto;width:600px;table-layout:fixed;background-color:rgb(255,198,201);">
+                    <tbody>
+                    <tr>
+                        <td style="background-color:rgb(255,198,201);padding:20px 8px 20px 7px;border:0px none transparent;">
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+        </td>
+    </tr>
+    </tbody>
+</table>

--- a/app/views/volunteer_mailer/box_request_email.html.erb
+++ b/app/views/volunteer_mailer/box_request_email.html.erb
@@ -16,12 +16,12 @@
     padding:0;
     background: rgb(255,255,255);
     }
-    table td { 
-    border-spacing: 0; 
-    border-collapse: collapse; 
-    border: 0 none; 
-    mso-table-lspace: 0pt; 
-    mso-table-rspace: 0pt; 
+    table td {
+    border-spacing: 0;
+    border-collapse: collapse;
+    border: 0 none;
+    mso-table-lspace: 0pt;
+    mso-table-rspace: 0pt;
     }
     /*+++++++++++++++++ MOBILE ++++++++++++++++++*/
     @media only screen and (max-width: 620px) {
@@ -281,7 +281,7 @@
                                                 <tbody>
                                                   <tr>
                                                     <td style="text-align:center;background-color:rgb(255,198,201);border-top-left-radius:14px;border-top-right-radius:14px;border-bottom-right-radius:14px;border-bottom-left-radius:14px;border:0px none transparent;padding:15px 30px;background-position:initial initial;background-repeat:initial initial;">
-                                                      <a href="" name="unlinked-bi2nkfg" style='text-decoration:none;color:rgb(255,255,255);font-family:"PT Sans", sans-serif;font-size:20px;' id="unlinked-bi2nkfg">I ACCEPT</a>
+                                                      <a href="<%= heroku_link("/box_requests/#{@box_request.id}/claim_review") %>" name="unlinked-bi2nkfg" style='text-decoration:none;color:rgb(255,255,255);font-family:"PT Sans", sans-serif;font-size:20px;' id="unlinked-bi2nkfg">I ACCEPT</a>
                                                     </td>
                                                   </tr>
                                                 </tbody>
@@ -300,7 +300,7 @@
                                                 <tbody>
                                                   <tr>
                                                     <td style="text-align:center;background-color:rgb(181,145,147);border-top-left-radius:14px;border-top-right-radius:14px;border-bottom-right-radius:14px;border-bottom-left-radius:14px;border:0px none transparent;padding:15px 30px;background-position:initial initial;background-repeat:initial initial;">
-                                                      <a href="" name="unlinked-q7sgqyf" style='text-decoration:none;color:rgb(255,255,255);font-family:"PT Sans", sans-serif;font-size:20px;' id="unlinked-q7sgqyf">I DECLINE</a>
+                                                      <a href="<%= heroku_link("/box_requests/#{@box_request.id}/claim_review") %>" name="unlinked-q7sgqyf" style='text-decoration:none;color:rgb(255,255,255);font-family:"PT Sans", sans-serif;font-size:20px;' id="unlinked-q7sgqyf">I DECLINE</a>
                                                     </td>
                                                   </tr>
                                                 </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,13 @@ Rails.application.routes.draw do
   get 'requesters/thank_you', to: 'requesters#thank_you', as: 'box_request_thank_you'
 
   post 'box_request_triage', to: "box_request_triage#create"
-  get 'box_request/already_claimed', to: 'box_requests#already_claimed'
+  get 'box_requests/:id/claim_review', to: "box_requests#claim_review", as: 'box_request_claim_review'
+  post 'box_requests/:id/claim_review', to: "box_requests#claim_review"
+  get 'box_request/already_claimed', to: 'box_requests#already_claimed', as: 'box_request_already_claimed'
+
+  get 'box_requests/:id/decline_review', to: "box_requests#decline_review", as: 'box_request_decline_review'
+  post 'box_requests/:id/decline_review', to: "box_requests#decline_review"
+  get 'box_requests/thanks_anyway', to: 'box_requests#thanks_anyway', as: 'box_request_thanks_anyway'
 
   get 'box_design/new', to: 'box_design#new'
   get 'box_design/claim/:box_id', to: 'box_design#claim'

--- a/db/migrate/20191005000003_add_review_declined_by_ids_to_box_request.rb
+++ b/db/migrate/20191005000003_add_review_declined_by_ids_to_box_request.rb
@@ -1,0 +1,5 @@
+class AddReviewDeclinedByIdsToBoxRequest < ActiveRecord::Migration[5.2]
+  def change
+    add_column :box_requests, :review_declined_by_ids, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_02_213913) do
+ActiveRecord::Schema.define(version: 2019_10_05_000003) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,6 +93,7 @@ ActiveRecord::Schema.define(version: 2019_09_02_213913) do
     t.bigint "reviewed_by_id"
     t.string "aasm_state"
     t.datetime "reviewed_at"
+    t.string "review_declined_by_ids", default: [], array: true
     t.index ["requester_id"], name: "index_box_requests_on_requester_id"
     t.index ["reviewed_by_id"], name: "index_box_requests_on_reviewed_by_id"
   end


### PR DESCRIPTION
Fix #218 
Fix #217 
Fix #11 

- Add heroku_link method
    - Add two ENV vars to env.example: HEROKU_APP_NAME and HEROKU_TEST_DB_URL
    - Determine if prod or staging using HEROKU_APP_NAME
        - Generate heroku url using HEROKU_APP_NAME and prod or staging
    - If dev, return a local link
- Add endpoint for claim_review after link in email is clicked
- Add endpoint and database field (review_declined_by_ids) to process review declines from email button
- Add thanks_anyway route and template (for response to decline_review)
- Update request received email template with links to claim_review and decline_review

Needs tests!