### PR TITLE
Update box_request_triage_controller to populate tag_list based on form responses

### DIFF
--- a/app/controllers/box_request_triage_controller.rb
+++ b/app/controllers/box_request_triage_controller.rb
@@ -39,6 +39,7 @@ class BoxRequestTriageController < ApplicationController
     requester.save!
 
     box_request = requester.box_requests.build
+    @abuse_types_response = @payload[:abuse_types]
 
     [
       :is_interested_in_counseling_services,
@@ -50,10 +51,55 @@ class BoxRequestTriageController < ApplicationController
       :question_re_referral_source,
       :summary,
     ].each do |box_request_attribute|
-      box_request.assign_attributes(box_request_attribute => @payload[box_request_attribute])
+        box_request.assign_attributes(box_request_attribute => @payload[box_request_attribute])
+    end
+
+    ### Prepopulate tags based on question data
+    [ :is_interested_in_counseling_services,
+      :is_interested_in_health_services,
+      :is_safe,
+      :is_underage,
+      :abuse_types,
+    ].each do |box_request_attribute|
+      if box_request_attribute == :abuse_types
+        if @abuse_types_response.include?("All of the Above")
+          @abuse_types = params[:abuseTypeOptions] - ["All of the Above"] # pull from original option set
+        else
+          @abuse_types = @abuse_types_response
+        end
+
+        @abuse_types.each do |abuse_type| # prepopulate tags
+          box_request.tag_list << abuse_type
+        end
+      elsif box_request_attribute == :is_safe
+        if YAML.load(@payload[box_request_attribute].to_s)
+          box_request.tag_list << "safe"
+        else
+          box_request.tag_list << "NOT SAFE"
+        end
+      elsif box_request_attribute == :is_underage
+        if YAML.load(@payload[box_request_attribute].to_s)
+          box_request.tag_list << "12+"
+        else
+          box_request.tag_list << "UNDERAGE"
+        end
+      elsif box_request_attribute == :is_interested_in_counseling_services
+        if YAML.load(@payload[box_request_attribute].to_s)
+          box_request.tag_list << "counseling"
+        end
+      elsif box_request_attribute == :is_interested_in_health_services
+        if YAML.load(@payload[box_request_attribute].to_s)
+          box_request.tag_list << "health_services"
+        end
+      end
     end
 
     box_request.save!
+
+    # Preserve requester's original abuse type submission data as box_request_abuse_types
+    @abuse_types_response.each do |abuse_type|
+      box_request.box_request_abuse_types.create!(abuse_type: AbuseType.where(name: abuse_type).first_or_create!)
+    end
 
     render json: { "redirect_url": box_request_thank_you_path },
            status: 200

--- a/app/models/box_request.rb
+++ b/app/models/box_request.rb
@@ -6,6 +6,7 @@ class BoxRequest < ApplicationRecord
 
   belongs_to :requester
   belongs_to :reviewed_by, optional: true, class_name: "User", foreign_key: :reviewed_by_id, inverse_of: :box_requests_as_reviewer
+  has_many :box_request_abuse_types
   has_one :box
 
   validates :requester, presence: true

--- a/app/models/box_request_abuse_type.rb
+++ b/app/models/box_request_abuse_type.rb
@@ -1,4 +1,8 @@
 class BoxRequestAbuseType < ApplicationRecord
   belongs_to :box_request
   belongs_to :abuse_type
+
+  def abuse_type_name
+    abuse_type.name
+  end
 end


### PR DESCRIPTION
Fix #220 

- For abuse_types, if "All of the Above" is selected, tag all abuse types that were on the form
	- even if user didn't select all abuse types
	- preserve User's original abuse type responses via association box_request_abuse_types
- Add relevant tags re age, safety, and resource interests
- Admin user will edit tags during BoxRequest Review phase

Needs tests!!!