### PR TITLE
Begin adding more detail to box_requests/index

### DIFF
--- a/app/models/box.rb
+++ b/app/models/box.rb
@@ -11,9 +11,9 @@ class Box < ApplicationRecord
 
   has_many :box_items
 
-  delegate :name, to: :designed_by, prefix: :designer, allow_nil: true
-  delegate :name, to: :assembled_by, prefix: :assembler, allow_nil: true
-  delegate :name, to: :shipped_by, prefix: :shipper, allow_nil: true
+  delegate :first_name, to: :designed_by, prefix: :designer, allow_nil: true
+  delegate :first_name, to: :assembled_by, prefix: :assembler, allow_nil: true
+  delegate :first_name, to: :shipped_by, prefix: :shipper, allow_nil: true
 
   def has_designer?
     return !self.designed_by.nil?
@@ -22,7 +22,7 @@ class Box < ApplicationRecord
   def has_assembler?
     return !self.assembled_by.nil?
   end
-  
+
   def has_shipper?
     return !self.shipped_by.nil?
   end
@@ -32,12 +32,12 @@ class Box < ApplicationRecord
   end
 
   aasm do
-    
+
     state :pending_review, :initial => true
     state :design_in_progress
     state :designed
     state :assembly_in_progress
-    state :assembled 
+    state :assembled
     state :shipping_in_progress
     state :shipped
 

--- a/app/models/box_request.rb
+++ b/app/models/box_request.rb
@@ -14,7 +14,8 @@ class BoxRequest < ApplicationRecord
   validates :question_re_referral_source, presence: true
   validates :question_re_current_situation, presence: true
 
-  delegate :designer_name, :assembler_name, :shipper_name, :followup_sent?, to: :box, allow_nil: true
+  delegate :first_name, to: :reviewed_by, prefix: :reviewer, allow_nil: true
+  delegate :designer_first_name, :assembler_first_name, :shipper_first_name, :followup_sent?, to: :box, allow_nil: true
   delegate :name, to: :reviewed_by, prefix: :reviewer, allow_nil: true
 
   scope :requested, ->(){ where(reviewed_by_id: nil) }
@@ -42,6 +43,10 @@ class BoxRequest < ApplicationRecord
     end
 
   end
+
+    def name
+      "#{requester.city}, #{requester.state} (#{tag_list.to_sentence})"
+    end
 
     def is_reviewed
       self.box &&

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,7 @@ class User < ApplicationRecord
   has_many :purchases, foreign_key: :purchased_by_id, inverse_of: :purchased_by, dependent: :restrict_with_error
   has_many :reimbursed_purchases, class_name: "Purchase", foreign_key: :reimbursed_by_id, inverse_of: :reimbursed_by, dependent: :restrict_with_error
 
+  delegate :first_name, to: :volunteer
   delegate :name, to: :volunteer
 
   def grant_all_permissions!

--- a/app/views/box_requests/index.html.erb
+++ b/app/views/box_requests/index.html.erb
@@ -6,6 +6,10 @@
                     html: { class: 'form-inline'},
                     url: box_requests_path,
                     method: :get do |f| %>
+
+  <span class="results">
+    <%= @box_requests.length %> box requests
+  </span>
   <%= select_tag     "filter_by",
                        options_for_select(
                            [:requested,
@@ -22,37 +26,74 @@
                        include_blank: "-- Filter options --",
                        placeholder: "",
                        class: "form-control" %>
-  <%= f.button :submit, "Filter", class: "form-group btn btn-success button", name: nil %>
+  <%= f.button :submit, "Filter", class: "form-group btn btn-success button pull-left", name: nil %>
 <% end %>
 
 <table class="table box-requests-table">
   <thead>
     <tr>
-      <th></th>
-      <th>Reviewed by</th>
-      <th>Designed by</th>
-      <th>Assembled by</th>
-      <th>Shipped by</th>
-      <th>Followup sent?</th>
+      <th>Name</th>
+      <th>Review</th>
+      <th>Design</th>
+      <th>Package</th>
+      <th>Ship</th>
+      <th>Followup</th>
     </tr>
   </thead>
 
   <tbody>
     <% @box_requests.each do |box_request| %>
+      <% box = box_request.box %>
       <tr>
-        <td><%= box_request.id %></td>
+        <td><%= box_request.name %></td>
         <td>
-          <%= box_request.reviewer_name %>
-          <% if box_request.reviewed_by == current_user %>
-            <%= link_to("review", edit_box_request_path(box_request)) %>
+          <%= box_request.reviewer_first_name %>
+          <% if box_request.review_declined_by_ids.include?(current_user.id) %>
+            (Declined)
           <% elsif !box_request.reviewed_by_id.present? %>
-            <%= link_to("claim", edit_box_request_path(box_request)) %>
+            <%= link_to("claim review", edit_box_request_path(box_request), class: "btn form-group btn-default button") %>
+          <% elsif box_request.reviewed_by == current_user && !box_request.is_reviewed %>
+            <%= link_to("review", edit_box_request_path(box_request), class: "btn form-group btn-default button") %>
           <% end %>
         </td>
-        <td><%= box_request.designer_name %></td>
-        <td><%= box_request.assembler_name %></td>
-        <td><%= box_request.shipper_name %></td>
-        <td><%= box_request.followup_sent? %></td>
+        <td>
+          <%= box_request.designer_first_name %>
+          <% if box %>
+            <% if box_request.reviewed? && !box.designed_by_id.present? %>
+              <%= link_to("Design now", box_design_new_path(box), class: "btn btn-default") %>
+              <%= link_to("Design later", box_design_new_path(box), class: "btn btn-default") %>
+            <% elsif box.designed_by == current_user && !box.is_designed %>
+              <%= link_to("design", box_design_new_path(box), class: "btn btn-default") %>
+            <% end %>
+          <% end %>
+        </td>
+        <td>
+          <%= box_request.assembler_first_name %>
+          <% if box %>
+            <% if box.designed? && !box.assembled_by_id.present? %>
+              <%= link_to("claim packaging (TBD)", box_assembly_new_path(box), class: "btn btn-default") %>
+            <% elsif box.assembled_by == current_user && !box.is_assembled %>
+              <%= link_to("package", box_assembly_new_path(box), class: "btn btn-default") %>
+            <% end %>
+          <% end %>
+        </td>
+        <td>
+          <%= box_request.shipper_first_name %>
+          <% if box %>
+            <% if box.assembled? && !box.shipped_by_id.present? %>
+              <%= link_to("claim shipping (TBD)", box_shipment_mark_as_shipped_path(box), class: "btn btn-default") %>
+            <% elsif box.shipped_by == current_user && !box.is_shipped %>
+              <%= link_to("mark as shipped", box_shipment_mark_as_shipped_path(box), class: "btn btn-default") %>
+            <% end %>
+          <% end %>
+        </td>
+        <td>
+          <% if box %>
+            <% if box.shipped? && !box_request.followup_sent? %>
+              <%= link_to("mark as follwed up (TBD)", root_path, class: "btn btn-default") %>
+            <% end %>
+          <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
Fix # 164

- This is a little messy, but gets us closer to the `Status` we need to see on BoxRequests index
- Had to adjust aasm method calls in BoxRequestsController to handle a couple states for BoxRequest (will need to add in the same fashion for BoxesController)
- Threaded first_name through delegation declarations to display first_name on Status index
- This page needs more work to offer options to Claim/Decline per Survivor Box "phase", and related tests will need to be changed. 