### PR TITLE
Create migrations to add missing foreign keys and indices

### DIFF
--- a/db/migrate/20191006172919_add_missing_foreign_keys.rb
+++ b/db/migrate/20191006172919_add_missing_foreign_keys.rb
@@ -1,6 +1,7 @@
 class AddMissingForeignKeys < ActiveRecord::Migration[5.2]
   def change
     # box_items table
+    add_foreign_key :box_items, :boxes
     add_foreign_key :box_items, :inventory_types
     add_foreign_key :box_items, :users, column: :created_by_id
     add_foreign_key :box_items, :users, column: :researched_by_id
@@ -27,8 +28,13 @@ class AddMissingForeignKeys < ActiveRecord::Migration[5.2]
     add_foreign_key :purchases, :users, column: :purchased_by_id
     add_foreign_key :purchases, :users, column: :reimbursed_by_id
 
+    # taggings
+    add_foreign_key :taggings, :tags
+
     # users
-    add_foreign_key :users, :users, column: :invited_by_id
     add_foreign_key :users, :volunteers, column: :volunteer_id
+
+    #volunteers
+    add_foreign_key :volunteers, :locations, column: :university_location_id
   end
 end

--- a/db/migrate/20191006172919_add_missing_foreign_keys.rb
+++ b/db/migrate/20191006172919_add_missing_foreign_keys.rb
@@ -1,0 +1,34 @@
+class AddMissingForeignKeys < ActiveRecord::Migration[5.2]
+  def change
+    # box_items table
+    add_foreign_key :box_items, :inventory_types
+    add_foreign_key :box_items, :users, column: :created_by_id
+    add_foreign_key :box_items, :users, column: :researched_by_id
+    add_foreign_key :box_items, :users, column: :updated_by_id
+    
+    # box_requests table
+    add_foreign_key :box_requests, :requesters
+
+    # boxes table
+    add_foreign_key :boxes, :users, column: :designed_by_id
+    add_foreign_key :boxes, :users, column: :design_reviewed_by_id
+    add_foreign_key :boxes, :users, column: :assembled_by_id
+    add_foreign_key :boxes, :users, column: :shipped_by_id
+    add_foreign_key :boxes, :purchases, column: :shipping_payment_id
+
+    # inventory_adjustments table
+    add_foreign_key :inventory_tallies, :inventory_types
+    
+    # message_logs table
+    add_foreign_key :message_logs, :users, column: :sent_to_id
+    add_foreign_key :message_logs, :users, column: :sent_by_id
+
+    # purchases table
+    add_foreign_key :purchases, :users, column: :purchased_by_id
+    add_foreign_key :purchases, :users, column: :reimbursed_by_id
+
+    # users
+    add_foreign_key :users, :users, column: :invited_by_id
+    add_foreign_key :users, :volunteers, column: :volunteer_id
+  end
+end

--- a/db/migrate/20191006173749_add_missing_indices.rb
+++ b/db/migrate/20191006173749_add_missing_indices.rb
@@ -1,0 +1,6 @@
+class AddMissingIndices < ActiveRecord::Migration[5.2]
+  def change
+    add_index :message_logs, :sent_to_id
+    add_index :message_logs, :sent_by_id
+  end
+end

--- a/db/migrate/20191006173749_add_missing_indices.rb
+++ b/db/migrate/20191006173749_add_missing_indices.rb
@@ -2,5 +2,7 @@ class AddMissingIndices < ActiveRecord::Migration[5.2]
   def change
     add_index :message_logs, :sent_to_id
     add_index :message_logs, :sent_by_id
+    add_index :active_storage_attachments, :record_id
+    add_index :volunteers, :university_location_id
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_05_000003) do
+ActiveRecord::Schema.define(version: 2019_10_06_173749) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -204,6 +204,8 @@ ActiveRecord::Schema.define(version: 2019_10_05_000003) do
     t.string "message_channel"
     t.string "message_type"
     t.index ["messageable_type", "messageable_id"], name: "index_message_logs_on_messageable_type_and_messageable_id"
+    t.index ["sent_by_id"], name: "index_message_logs_on_sent_by_id"
+    t.index ["sent_to_id"], name: "index_message_logs_on_sent_to_id"
   end
 
   create_table "purchases", force: :cascade do |t|
@@ -321,18 +323,35 @@ ActiveRecord::Schema.define(version: 2019_10_05_000003) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "attendances", "meetings"
   add_foreign_key "attendances", "users"
+  add_foreign_key "box_items", "inventory_types"
+  add_foreign_key "box_items", "users", column: "created_by_id"
+  add_foreign_key "box_items", "users", column: "researched_by_id"
+  add_foreign_key "box_items", "users", column: "updated_by_id"
   add_foreign_key "box_request_abuse_types", "abuse_types"
   add_foreign_key "box_request_abuse_types", "box_requests"
+  add_foreign_key "box_requests", "requesters"
   add_foreign_key "box_requests", "users", column: "reviewed_by_id"
   add_foreign_key "boxes", "box_requests"
+  add_foreign_key "boxes", "purchases", column: "shipping_payment_id"
+  add_foreign_key "boxes", "users", column: "assembled_by_id"
+  add_foreign_key "boxes", "users", column: "design_reviewed_by_id"
+  add_foreign_key "boxes", "users", column: "designed_by_id"
+  add_foreign_key "boxes", "users", column: "shipped_by_id"
   add_foreign_key "core_box_items", "abuse_types"
   add_foreign_key "core_box_items", "inventory_types"
   add_foreign_key "inventory_adjustments", "box_items"
   add_foreign_key "inventory_adjustments", "inventory_tallies"
   add_foreign_key "inventory_adjustments", "purchases"
+  add_foreign_key "inventory_tallies", "inventory_types"
   add_foreign_key "inventory_tallies", "locations", column: "storage_location_id"
   add_foreign_key "meetings", "locations"
   add_foreign_key "meetings", "meeting_types"
+  add_foreign_key "message_logs", "users", column: "sent_by_id"
+  add_foreign_key "message_logs", "users", column: "sent_to_id"
   add_foreign_key "purchases", "locations"
+  add_foreign_key "purchases", "users", column: "purchased_by_id"
+  add_foreign_key "purchases", "users", column: "reimbursed_by_id"
   add_foreign_key "user_permissions", "users"
+  add_foreign_key "users", "users", column: "invited_by_id"
+  add_foreign_key "users", "volunteers"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2019_10_06_173749) do
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_id"], name: "index_active_storage_attachments_on_record_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
@@ -318,11 +319,13 @@ ActiveRecord::Schema.define(version: 2019_10_06_173749) do
     t.boolean "underage"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["university_location_id"], name: "index_volunteers_on_university_location_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "attendances", "meetings"
   add_foreign_key "attendances", "users"
+  add_foreign_key "box_items", "boxes"
   add_foreign_key "box_items", "inventory_types"
   add_foreign_key "box_items", "users", column: "created_by_id"
   add_foreign_key "box_items", "users", column: "researched_by_id"
@@ -351,7 +354,8 @@ ActiveRecord::Schema.define(version: 2019_10_06_173749) do
   add_foreign_key "purchases", "locations"
   add_foreign_key "purchases", "users", column: "purchased_by_id"
   add_foreign_key "purchases", "users", column: "reimbursed_by_id"
+  add_foreign_key "taggings", "tags"
   add_foreign_key "user_permissions", "users"
-  add_foreign_key "users", "users", column: "invited_by_id"
   add_foreign_key "users", "volunteers"
+  add_foreign_key "volunteers", "locations", column: "university_location_id"
 end


### PR DESCRIPTION
Resolves #170

### Description
Reviewed `schema.rb` to find tables that had foreign keys, but were missing the `add_foreign_key` statement below the table. Also reviewed the file to find missing `index` fields in tables. Created two migrations, one to add the missing foreign keys and one to add the missing indices. 

### Type of change
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Ran tests on `develop` branch and `add-foreign-keys` branch to make sure none of the tests failed after the migrations. 

On ‘develop’ branch:
```
Finished in 13.39 seconds (files took 31.48 seconds to load)
303 examples, 57 failures, 116 pending
```

On ‘add-foreign-keys’ branch:
```
Finished in 3.23 seconds (files took 3.25 seconds to load)
303 examples, 57 failures, 116 pending
```
