### PR TITLE
Adjust Clickable Area on Checkbox - 144

### DIFF
--- a/app/javascript/src/components/box-request-form/BoxRequestForm.js
+++ b/app/javascript/src/components/box-request-form/BoxRequestForm.js
@@ -163,8 +163,8 @@ class BoxRequestForm extends React.Component {
   renderAbuseTypes() {
     const abuseTypes = this.state.abuseTypeOptions.map((type) =>
       <div class="row form-check">
-        <input class="form-check-input" type="checkbox" value={type} id="abuse_types" onChange={this.handleCheckBoxChange} checked={this.state.boxRequest.abuse_types.includes(type)} />
-        <label class="form-check-label" for="abuse_types">{type}</label>
+        <input class="form-check-input" type="checkbox" value={type} id={type} onChange={this.handleCheckBoxChange} checked={this.state.boxRequest.abuse_types.includes(type)} />
+        <label class="form-check-label" for={type}>{type}</label>
       </div>
     );
 


### PR DESCRIPTION
Resolves #144  <!--fill issue number-->

### Description

The labels for the checkboxes on the box request form where not clickable (aside from the first one) because the "for" attribute on the label and the "id" attribute on the checkbox which allow the template to connect the two was not unique to each checkbox within the loop. I changed both the for and id to be the type variable in order to keep it unique for each checkbox within the loop so that the labels would be clickable areas.

### Type of change

- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

This was not tested (aside from manually clicking things) as it is a UI I change and to my knowledge we don't have any front-end integration testing test up. 
