### PR TITLE
feature/truncate-content-column-message-logs

### DIFF
--- a/app/views/message_logs/index.html.erb
+++ b/app/views/message_logs/index.html.erb
@@ -22,7 +22,7 @@
         <th scope="row"><%= message_log.message_type %></th>
         <td><%= message_log.id %></td>
         <%# Strip HTML tags and hard carriage returns since content returns as a long HTML string%>
-        <td><%= strip_tags(message_log.content).gsub(/=0D/, "") %></td>
+        <td><%= truncate(strip_tags(message_log.content).gsub(/=0D/, ""), length: 25) %></td>
         <td><%= message_log.delivery_type %></td>
         <td><%= message_log.delivery_status %></td>
         <td><%= message_log.sent_to.email %></td>


### PR DESCRIPTION
wrapped message_log.content in a truncate so that it truncates after 25 characters, this is for the /message_logs uri

<!--Read comments, before commiting pull request read checklist again
# Checklist:
- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
-->

Resolves #248 <!--fill issue number-->