### PR TITLE
updates to the readme to help new people

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,12 @@ $ bundle install
 $ yarn install
 $ rake dev:setup
 $ heroku local -f Procfile.dev
+# if you chose the local route, then you are good to go on:
+  http://localhost:5000
+  $ rspec (to run the test suite)
 # If you chose the Docker route:
   $ docker-compose start -or- $ docker-compose up
-# Else
-  $ rails s
+  http://localhost:3000
 $ rspec (to run the test suite)
 ```
 


### PR DESCRIPTION
Helps new people joining this repo to get started faster.

### Description

This change was motivated by a couple hiccups when I joined, trying to get everything running on my system. I am not sure about the Docker setup, but these changes are for the local setup only applied to the README.md file. On local this project runs at localhost:5000 and does not require rails server to start the server if you get the heroku command running.

### Type of change

- Documentation update

### How Has This Been Tested?

This has been tested me installing this repo for the first time 4 days ago.