### PR TITLE
238 replace hard coded abuse types

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ group :test do
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
   # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'chromedriver-helper'
+  gem 'webdrivers', '~> 4.0'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,8 +48,6 @@ GEM
       activerecord (~> 5.0)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     aws-eventstream (1.0.3)
     aws-partitions (1.193.0)
@@ -83,9 +81,6 @@ GEM
       xpath (~> 3.2)
     childprocess (1.0.1)
       rake (< 13.0)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
@@ -115,7 +110,6 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.0)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
     jmespath (1.4.0)
@@ -251,6 +245,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.1.2)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webpacker (4.0.7)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -271,7 +269,6 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
   capybara (>= 2.15)
-  chromedriver-helper
   devise (~> 4.6)
   devise_invitable (~> 2.0.0)
   factory_bot_rails
@@ -293,6 +290,7 @@ DEPENDENCIES
   twilio-ruby (~> 5.25)
   tzinfo-data
   web-console (>= 3.3.0)
+  webdrivers (~> 4.0)
   webpacker (~> 4.x)
 
 RUBY VERSION

--- a/app/controllers/abuse_types_controller.rb
+++ b/app/controllers/abuse_types_controller.rb
@@ -1,0 +1,6 @@
+class AbuseTypesController < ApplicationController
+  # GET /attendances.json
+  def index
+    @abuse_types = AbuseType.all
+  end
+end

--- a/app/javascript/src/components/box-request-form/BoxRequestForm.js
+++ b/app/javascript/src/components/box-request-form/BoxRequestForm.js
@@ -49,22 +49,15 @@ class BoxRequestForm extends React.Component {
   }
 
   componentDidMount() {
-    const token = document.getElementsByName('csrf-token')[0].content;
     const { abuseTypeOptions } = this.state;
 
-    fetch('/abuse_types.json', {
-      credentials: 'same-origin',
-      headers: { 'X-CSRF-Token': token },
-    }).then((response) => response.json())
-    .then((data) => {
-      const abuseTypes = data.map(({ name }) => {
-        const abuseTypeName = name.substr(0, 1).toUpperCase() + name.substr(1).toLowerCase();
+    fetch('/abuse_types.json')
+      .then(response => response.json())
+      .then((data) => {
+        const abuseTypes = data.map(({ name }) => name)
 
-        return abuseTypeName
-      })
-
-      this.setState({ abuseTypeOptions: [...abuseTypes, ...abuseTypeOptions] })
-    });
+        this.setState({ abuseTypeOptions: [...abuseTypes, ...abuseTypeOptions] })
+      });
   }
 
   handleChange(event) {

--- a/app/javascript/src/components/box-request-form/BoxRequestForm.js
+++ b/app/javascript/src/components/box-request-form/BoxRequestForm.js
@@ -11,7 +11,7 @@ class BoxRequestForm extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      abuseTypeOptions: ["Emotional", "Physical", "Sexual", "All of the Above"],
+      abuseTypeOptions: ["All of the Above"],
       attemptedSubmit: false,
       step: 0,
       boxRequest: {
@@ -46,6 +46,25 @@ class BoxRequestForm extends React.Component {
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handlePaginatePrevious = this.handlePaginatePrevious.bind(this);
     this.handlePaginateForward = this.handlePaginateForward.bind(this);
+  }
+
+  componentDidMount() {
+    const token = document.getElementsByName('csrf-token')[0].content;
+    const { abuseTypeOptions } = this.state;
+
+    fetch('/abuse_types.json', {
+      credentials: 'same-origin',
+      headers: { 'X-CSRF-Token': token },
+    }).then((response) => response.json())
+    .then((data) => {
+      const abuseTypes = data.map(({ name }) => {
+        const abuseTypeName = name.substr(0, 1).toUpperCase() + name.substr(1).toLowerCase();
+
+        return abuseTypeName
+      })
+
+      this.setState({ abuseTypeOptions: [...abuseTypes, ...abuseTypeOptions] })
+    });
   }
 
   handleChange(event) {
@@ -373,21 +392,21 @@ class BoxRequestForm extends React.Component {
         <div class="row section-top">
           <label class="section-label">Phone</label>
           <input type="text" class="form-control" name="phone" value={boxRequest.phone} onChange={this.handleChange} />
-          <div class="col-6"> 
+          <div class="col-6">
             <div class="row">
               <label class="following-question">Okay to call?*</label>
               <div class="form-check form-check-inline">
                 <input class="form-check-input" type="radio" name="ok_to_call" id="ok_to_call_true" onChange={this.handleRadioChange} checked={boxRequest.ok_to_call}/>
                 <label class="form-check-label" for="ok_to_call">Yes</label>
               </div>
-              
+
               <div class="form-check form-check-inline">
                 <input class="form-check-input" type="radio" name="ok_to_call" id="ok_to_call_false" onChange={this.handleRadioChange} checked={boxRequest.ok_to_call === false}/>
                 <label class="form-check-label" for="ok_to_call_false">No</label>
               </div>
             </div>
           </div>
-          <div class="col-6"> 
+          <div class="col-6">
             <div class="row">
               <label class="following-question">Okay to text?*</label>
               <div class="form-check form-check-inline">
@@ -412,7 +431,7 @@ class BoxRequestForm extends React.Component {
   }
 
   renderProgressBar() {
-    const { first_name, last_name, email, street_address, city, state, zip, ok_to_mail, ok_to_call, ok_to_text, ok_to_email, question_re_affect, 
+    const { first_name, last_name, email, street_address, city, state, zip, ok_to_mail, ok_to_call, ok_to_text, ok_to_email, question_re_affect,
       question_re_referral_source, question_re_current_situation, is_safe, is_interested_in_counseling_services, is_interested_in_health_services, is_underage, abuse_types } = this.state.boxRequest;
 
     const completedFields = [first_name, last_name, email, street_address, city, state, zip, question_re_affect,

--- a/app/javascript/src/utilities/index.js
+++ b/app/javascript/src/utilities/index.js
@@ -2,11 +2,11 @@ export const keyHandler = (options = {}) => e => {
     if(typeof options !== 'object' || options === null) {
         return;
     }
-    
+
     const {
-        fn = () => {}, 
-        keys = ['Enter', ' '], 
-        stopProp = true, 
+        fn = () => {},
+        keys = ['Enter', ' '],
+        stopProp = true,
         prevDef = true
     } = options;
 

--- a/app/views/abuse_types/_abuse_type.json.jbuilder
+++ b/app/views/abuse_types/_abuse_type.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! abuse_type, :id, :name, :created_at, :updated_at
+json.url abuse_types_url(abuse_type, format: :json)

--- a/app/views/abuse_types/index.json.jbuilder
+++ b/app/views/abuse_types/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @abuse_types, partial: "abuse_types/abuse_type", as: :abuse_type

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   resources :purchases
   resource :user_management, only: %i[show create destroy], controller: :user_management
   resources :volunteers
+  resources :abuse_types, only: %i[index]
 
   get 'login_demo/index'
   get 'contact', to: 'home#contact'

--- a/spec/controllers/abuse_types_controller_spec.rb
+++ b/spec/controllers/abuse_types_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe AbuseTypesController, type: :controller do
+  has_authenticated_user
+
+  describe 'GET #index' do
+    it 'returns a success response' do
+      get :index, params: { format: :json }
+
+      expect(response).to be_successful
+    end
+  end
+end

--- a/spec/factories/abuse_type.rb
+++ b/spec/factories/abuse_type.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :abuse_type do
+    sequence(:name) { |n| "Abuse Type #{n}" }
+  end
+end

--- a/spec/features/box_request_form_feature.rb
+++ b/spec/features/box_request_form_feature.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+feature 'Box Request Form', type: :feature do
+  let!(:abuse_type) { FactoryBot.create(:abuse_type) }
+
+  before do
+    login
+  end
+
+  it 'shows all abuse types', js: true do
+    visit requesters_new_path
+
+    expect(page).to have_content(abuse_type.name)
+    expect(page).to have_content("All of the Above")
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,11 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 require_relative 'support/controller_macros'
+require_relative 'support/authentication_helpers'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'capybara/rspec'
+require 'capybara/rails'
+require 'webdrivers/chromedriver'
 require 'aasm/rspec'
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -62,6 +66,17 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include AuthenticationHelpers, type: :feature
   config.extend ControllerMacros, type: :controller
+end
 
+Capybara.configure do |config|
+  config.default_max_wait_time = 5
+  config.match = :prefer_exact
+end
+
+Capybara.register_driver :selenium do |app|
+  options = Selenium::WebDriver::Chrome::Options.new
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -1,0 +1,10 @@
+module AuthenticationHelpers
+  def login(user = FactoryBot.create(:user))
+    user.update_attributes(password: 'password', password_confirmation: 'password')
+
+    visit user_session_path
+    fill_in :user_email, with: user.email
+    fill_in :user_password, with: 'password'
+    click_on 'commit'
+  end
+end


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again
# Checklist:
- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
-->

Resolves #238 

### Description
All abuse types were hard coded in `app/javascript/src/components/box-request-form/BoxRequestForm.js`. Now, we have the `/abuse_types.json` path, that retrieves all the database abuse types
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?

List any dependencies that are required for this change. (gems, js libraries, etc.)
Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Tested with capybara, checking that the page displays the abuse types from our DB and has the default `"All of the Above"` option.
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Do we need to do anything else to verify your changes?
If so, provide instructions (including any relevant configuration) so that
we can reproduce? -->

### Screenshots
![image](https://user-images.githubusercontent.com/35704671/66521145-f665d500-eac0-11e9-8750-7ca49215b373.png)

<!--Optional. Delete if not relevant.
Include screenshots (before / after) for style changes, highlight
edited element.-->
