### PR TITLE
Change btn-default (Bootstrap 3) to btn-outline-secondary (Bootstrap 4)

### DIFF
--- a/app/views/box_requests/index.html.erb
+++ b/app/views/box_requests/index.html.erb
@@ -60,10 +60,10 @@
           <%= box_request.designer_first_name %>
           <% if box %>
             <% if box_request.reviewed? && !box.designed_by_id.present? %>
-              <%= link_to("Design now", box_design_new_path(box), class: "btn btn-default") %>
-              <%= link_to("Design later", box_design_new_path(box), class: "btn btn-default") %>
+              <%= link_to("Design now", box_design_new_path(box), class: "btn btn-outline-secondary") %>
+              <%= link_to("Design later", box_design_new_path(box), class: "btn btn-outline-secondary") %>
             <% elsif box.designed_by == current_user && !box.is_designed %>
-              <%= link_to("design", box_design_new_path(box), class: "btn btn-default") %>
+              <%= link_to("design", box_design_new_path(box), class: "btn btn-outline-secondary") %>
             <% end %>
           <% end %>
         </td>
@@ -71,9 +71,9 @@
           <%= box_request.assembler_first_name %>
           <% if box %>
             <% if box.designed? && !box.assembled_by_id.present? %>
-              <%= link_to("claim packaging (TBD)", box_assembly_new_path(box), class: "btn btn-default") %>
+              <%= link_to("claim packaging (TBD)", box_assembly_new_path(box), class: "btn btn-outline-secondary") %>
             <% elsif box.assembled_by == current_user && !box.is_assembled %>
-              <%= link_to("package", box_assembly_new_path(box), class: "btn btn-default") %>
+              <%= link_to("package", box_assembly_new_path(box), class: "btn btn-outline-secondary") %>
             <% end %>
           <% end %>
         </td>
@@ -81,16 +81,16 @@
           <%= box_request.shipper_first_name %>
           <% if box %>
             <% if box.assembled? && !box.shipped_by_id.present? %>
-              <%= link_to("claim shipping (TBD)", box_shipment_mark_as_shipped_path(box), class: "btn btn-default") %>
+              <%= link_to("claim shipping (TBD)", box_shipment_mark_as_shipped_path(box), class: "btn btn-outline-secondary") %>
             <% elsif box.shipped_by == current_user && !box.is_shipped %>
-              <%= link_to("mark as shipped", box_shipment_mark_as_shipped_path(box), class: "btn btn-default") %>
+              <%= link_to("mark as shipped", box_shipment_mark_as_shipped_path(box), class: "btn btn-outline-secondary") %>
             <% end %>
           <% end %>
         </td>
         <td>
           <% if box %>
             <% if box.shipped? && !box_request.followup_sent? %>
-              <%= link_to("mark as follwed up (TBD)", root_path, class: "btn btn-default") %>
+              <%= link_to("mark as follwed up (TBD)", root_path, class: "btn btn-outline-secondary") %>
             <% end %>
           <% end %>
         </td>

--- a/app/views/box_requests/index.html.erb
+++ b/app/views/box_requests/index.html.erb
@@ -51,9 +51,9 @@
           <% if box_request.review_declined_by_ids.include?(current_user.id) %>
             (Declined)
           <% elsif !box_request.reviewed_by_id.present? %>
-            <%= link_to("claim review", edit_box_request_path(box_request), class: "btn form-group btn-default button") %>
+            <%= link_to("claim review", edit_box_request_path(box_request), class: "btn form-group btn-outline-secondary button") %>
           <% elsif box_request.reviewed_by == current_user && !box_request.is_reviewed %>
-            <%= link_to("review", edit_box_request_path(box_request), class: "btn form-group btn-default button") %>
+            <%= link_to("review", edit_box_request_path(box_request), class: "btn form-group btn-outline-secondary button") %>
           <% end %>
         </td>
         <td>


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again
# Checklist:
- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
-->

Resolves #241 <!--fill issue number-->

### Description

Bootstrap 4 doesn't have the `btn-default` class anymore. The closest is `btn-outline-secondary` according to https://stackoverflow.com/questions/49339432/what-is-the-equivalent-of-the-bootstrap-3-btn-default-class-in-bootstrap-4

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?

List any dependencies that are required for this change. (gems, js libraries, etc.)
Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

* Create 5 `BoxRequest`s:
    * `designer_first_name` populated
    * `assembler_first_name` populated
    * `shipper_first_name` populated
    * `box.shipped && !box_request.followup_sent`
    * A new `BoxRequest` with no reviewer
   * A `BoxRequest` with `current_user` assigned but not yet reviewed

 to test all the branches of view logic where this button can come up.

Bonus points: update `spec/factories/box_request.rb` to generate a factory for all of these possible `BoxRequest` conditions - maybe merits a new issue?

<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Do we need to do anything else to verify your changes?
If so, provide instructions (including any relevant configuration) so that
we can reproduce? -->

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/6099983/66580942-d1b34100-eb44-11e9-86e9-77d11d55fb43.png)

After:
Screenshot showing one hovered (the solid one ) and the other not (outlined /default) : 
![image](https://user-images.githubusercontent.com/6099983/66580321-d4f9fd00-eb43-11e9-91fe-c884fe43d187.png)

![image](https://user-images.githubusercontent.com/6099983/66580531-2acea500-eb44-11e9-8fa6-80dee67949a3.png)



<!--Optional. Delete if not relevant.
Include screenshots (before / after) for style changes, highlight
edited element.-->
