### PR TITLE
Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,13 @@ Please check out https://www.voicesofconsent.org/what-we-do as well as the rest 
 See our CONTRIBUTING.md
 
 # Background
-We've started a few reference documents based on questions we've been asked. Check out the [/notes](notes) folder in the repo, and please ask questions in the Ruby for Good Slack or on Github so we can improve our references.
+We've started a few reference documents based on questions we've been asked. Make sure you also read our [background.md](notes/background.md), and check out the [database-diagram.png](notes/database-diagram.png) all of which is located in the [/notes](notes) folder in the repo.
+
+Also located in the [/notes](notes) folder is [database-diagram.dot](notes/database-diagram.dot) which is used to create the [database diagram.png](notes/database-diagram.png). If you want to edit this file and generate new versions of the [database-diagram.png](notes/database-diagram.png), visit http://graphviz.it/ and paste the code from your [database-diagram.dot](notes/database-diagram.dot). Make sure you erase all the code on this website and replace it with the entire contents of your .dot file to see your diagram properly.
+
+If you want to know more about how to update the [database-diagram.png](notes/database-diagram.png), please checkout Casey Watts' instructional post on graphviz at https://gist.github.com/caseywatts/be69bf941fa1f8e264bd07de698366a0.
+
+If you have any questions please feel free to reach out in the Ruby for Good Slack or on Github so we can improve our references.
 
 # Setting Up Development
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please check out https://www.voicesofconsent.org/what-we-do as well as the rest 
 See our CONTRIBUTING.md
 
 # Background
-We've started a few reference documents based on questions we've been asked. Check out the /notes folder in the repo, and please ask questions in the Ruby for Good Slack or on Github so we can improve our references.
+We've started a few reference documents based on questions we've been asked. Check out the https://github.com/rubyforgood/voices-of-consent/tree/develop/notes folder in the repo, and please ask questions in the Ruby for Good Slack or on Github so we can improve our references.
 
 # Setting Up Development
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please check out https://www.voicesofconsent.org/what-we-do as well as the rest 
 See our CONTRIBUTING.md
 
 # Background
-We've started a few reference documents based on questions we've been asked. Check out the https://github.com/rubyforgood/voices-of-consent/tree/develop/notes folder in the repo, and please ask questions in the Ruby for Good Slack or on Github so we can improve our references.
+We've started a few reference documents based on questions we've been asked. Check out the [/notes](notes) folder in the repo, and please ask questions in the Ruby for Good Slack or on Github so we can improve our references.
 
 # Setting Up Development
 


### PR DESCRIPTION
Resolves #259  and Resolves #260

### Description

These changes are to update the README.md with all relevant documentation about this project to make onboarding new developers a better overall experience.

Add link under the Background section on README to link to the background.md
Add link under the Background section on README to link to the database-diagram.png
Add link under the Background section on README to link to the database-diagram.dot
Add link to Casey Watts' instructional post re graphviz, https://gist.github.com/caseywatts/be69bf941fa1f8e264bd07de698366a0
Added instruction for getting started editing a .dot file on http://graphviz.it/

### Type of change

- Documentation update

### How Has This Been Tested?

I tested the links my self on github and on local.