### PR TITLE
Convert form_with files to simple_form

### DIFF
--- a/app/views/box_request_abuse_types/_form.html.erb
+++ b/app/views/box_request_abuse_types/_form.html.erb
@@ -1,27 +1,13 @@
-<%= form_with(model: box_request_abuse_type, local: true) do |form| %>
-  <% if box_request_abuse_type.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(box_request_abuse_type.errors.count, "error") %> prohibited this box_request_abuse_type from being saved:</h2>
+<%= simple_form_for(@box_request_abuse_type, html: { class: 'form-inline' }) do |f| %>
+  <%= f.error_notification %>
+  <%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
 
-      <ul>
-      <% box_request_abuse_type.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <div class="field">
-    <%= form.label :box_request_id %>
-    <%= form.text_field :box_request_id %>
+  <div class="form-inputs">
+    <%= f.association :box_request %>
+    <%= f.association :abuse_type %>
   </div>
 
-  <div class="field">
-    <%= form.label :abuse_type_id %>
-    <%= form.text_field :abuse_type_id %>
-  </div>
-
-  <div class="actions">
-    <%= form.submit %>
+  <div class="form-actions">
+    <%= f.button :submit %>
   </div>
 <% end %>

--- a/app/views/boxes/_form.html.erb
+++ b/app/views/boxes/_form.html.erb
@@ -1,57 +1,18 @@
-<%= form_with(model: box, local: true) do |form| %>
-  <% if box.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(box.errors.count, "error") %> prohibited this box from being saved:</h2>
+<%= simple_form_for(@box, html: { class: 'form-inline' }) do |f| %>
+  <%= f.error_notification %>
+  <%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
 
-      <ul>
-      <% box.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <div class="field">
-    <%= form.label :box_request_id %>
-    <%= form.text_field :box_request_id %>
+  <div class="form-inputs">
+    <%= f.association :box_request %>
+    <%= f.association :designed_by %>
+    <%= f.association :design_reviewed_by %>
+    <%= f.association :shipped_by %>
+    <%= f.association :shipping_payment %>
+    <%= f.input :shipped_at %>
+    <%= f.input :shipment_tracking_number %>
   </div>
 
-  <div class="field">
-    <%= form.label :designed_by_id %>
-    <%= form.text_field :designed_by_id %>
-  </div>
-
-  <div class="field">
-    <%= form.label :design_reviewed_by_id %>
-    <%= form.text_field :design_reviewed_by_id %>
-  </div>
-
-  <div class="field">
-    <%= form.label :assembled_by_id %>
-    <%= form.text_field :assembled_by_id %>
-  </div>
-
-  <div class="field">
-    <%= form.label :shipped_by_id %>
-    <%= form.text_field :shipped_by_id %>
-  </div>
-
-  <div class="field">
-    <%= form.label :shipping_payment_id %>
-    <%= form.text_field :shipping_payment_id %>
-  </div>
-
-  <div class="field">
-    <%= form.label :shipped_at %>
-    <%= form.datetime_select :shipped_at %>
-  </div>
-
-  <div class="field">
-    <%= form.label :shipment_tracking_number %>
-    <%= form.text_field :shipment_tracking_number %>
-  </div>
-
-  <div class="actions">
-    <%= form.submit %>
+  <div class="form-actions">
+    <%= f.button :submit %>
   </div>
 <% end %>

--- a/app/views/meetings/_form.html.erb
+++ b/app/views/meetings/_form.html.erb
@@ -1,47 +1,27 @@
-<%= form_with(model: meeting, local: true) do |form| %>
-  <% if meeting.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(meeting.errors.count, "error") %> prohibited this meeting from being saved:</h2>
+<%= simple_form_for(@meeting, html: { class: 'form-inline' }) do |f| %>
+  <%= f.error_notification %>
+  <%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
 
-      <ul>
-      <% meeting.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <div class="field">
-    <%= form.label :meeting_type_id %>
-    <%= form.text_field :meeting_type_id %>
+  <div class="form-inputs">
+    <%= f.association :meeting_type %>
+    <%= f.association :location %>
+    <%= f.input :title %>
+    <%= f.input :start_time,
+                as: :date_time_picker,
+                include_blank: true,
+                required: false,
+                input_html: { value: f.object.start_time,
+                              class: "form-field-display-block form-control datetimepicker" } %>
+    <%= f.input :end_time,
+                as: :date_time_picker,
+                include_blank: true,
+                required: false,
+                input_html: { value: f.object.end_time,
+                              class: "form-field-display-block form-control datetimepicker" } %>
+    <%= f.input :tenative %>
   </div>
 
-  <div class="field">
-    <%= form.label :title %>
-    <%= form.text_field :title %>
-  </div>
-
-  <div class="field">
-    <%= form.label :location_id %>
-    <%= form.text_field :location_id %>
-  </div>
-
-  <div class="field">
-    <%= form.label :start_time %>
-    <%= form.datetime_select :start_time %>
-  </div>
-
-  <div class="field">
-    <%= form.label :end_time %>
-    <%= form.datetime_select :end_time %>
-  </div>
-
-  <div class="field">
-    <%= form.label :tenative %>
-    <%= form.check_box :tenative %>
-  </div>
-
-  <div class="actions">
-    <%= form.submit %>
+  <div class="form-actions">
+    <%= f.button :submit %>
   </div>
 <% end %>

--- a/app/views/volunteers/_form.html.erb
+++ b/app/views/volunteers/_form.html.erb
@@ -1,92 +1,26 @@
-<%= form_with(model: volunteer, local: true) do |form| %>
-  <% if volunteer.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(volunteer.errors.count, "error") %> prohibited this volunteer from being saved:</h2>
+<%= simple_form_for(@volunteer, html: { class: 'form-inline' }) do |f| %>
+  <%= f.error_notification %>
+  <%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
 
-      <ul>
-      <% volunteer.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <div class="field">
-    <%= form.label :first_name %>
-    <%= form.text_field :first_name %>
+  <div class="form-inputs">
+    <%= f.input :first_name %>
+    <%= f.input :last_name %>
+    <%= f.input :street_address %>
+    <%= f.input :city %>
+    <%= f.input :state %>
+    <%= f.input :zip %>
+    <%= f.input :county %>
+    <%= f.input :phone %>
+    <%= f.association :university_location %>
+    <%= f.input :graduation_year %>
+    <%= f.input :ok_to_email %>
+    <%= f.input :ok_to_text %>
+    <%= f.input :ok_to_call %>
+    <%= f.input :ok_to_mail %>
+    <%= f.input :underage %>
   </div>
 
-  <div class="field">
-    <%= form.label :last_name %>
-    <%= form.text_field :last_name %>
-  </div>
-
-  <div class="field">
-    <%= form.label :street_address %>
-    <%= form.text_field :street_address %>
-  </div>
-
-  <div class="field">
-    <%= form.label :city %>
-    <%= form.text_field :city %>
-  </div>
-
-  <div class="field">
-    <%= form.label :state %>
-    <%= form.text_field :state %>
-  </div>
-
-  <div class="field">
-    <%= form.label :zip %>
-    <%= form.number_field :zip %>
-  </div>
-
-  <div class="field">
-    <%= form.label :county %>
-    <%= form.text_field :county %>
-  </div>
-
-  <div class="field">
-    <%= form.label :phone %>
-    <%= form.text_field :phone %>
-  </div>
-
-  <div class="field">
-    <%= form.label :university_location_id %>
-    <%= form.number_field :university_location_id %>
-  </div>
-
-  <div class="field">
-    <%= form.label :graduation_year %>
-    <%= form.number_field :graduation_year %>
-  </div>
-
-  <div class="field">
-    <%= form.label :ok_to_email %>
-    <%= form.check_box :ok_to_email %>
-  </div>
-
-  <div class="field">
-    <%= form.label :ok_to_text %>
-    <%= form.check_box :ok_to_text %>
-  </div>
-
-  <div class="field">
-    <%= form.label :ok_to_call %>
-    <%= form.check_box :ok_to_call %>
-  </div>
-
-  <div class="field">
-    <%= form.label :ok_to_mail %>
-    <%= form.check_box :ok_to_mail %>
-  </div>
-
-  <div class="field">
-    <%= form.label :underage %>
-    <%= form.check_box :underage %>
-  </div>
-
-  <div class="actions">
-    <%= form.submit %>
+  <div class="form-actions">
+    <%= f.button :submit %>
   </div>
 <% end %>


### PR DESCRIPTION
Fixes #62 

We'd used rails g scaffold before adding simple_form, so these were the leftover views that needed to be converted to simple_form for better/more consistent look and feel.