### PR TITLE
Add fontawesome and add icons to the box_requests page

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -23,6 +23,7 @@ import 'jquery'
 import 'bootstrap/js/dist/util'
 import 'bootstrap/js/dist/carousel'
 import 'bootstrap/js/dist/dropdown'
+import '@fortawesome/fontawesome-free/js/all'
 
 // application entry
 // import 'main'

--- a/app/javascript/src/stylesheets/application.scss
+++ b/app/javascript/src/stylesheets/application.scss
@@ -3,6 +3,8 @@
 @import 'variables';
 @import 'box_request_layout';
 @import 'navigation';
+$fa-font-path: '~@fortawesome/fontawesome-free/webfonts';
+@import '~@fortawesome/fontawesome-free/scss/regular';
 
 $body-bg: #ffc0cb;
 $container-bg: #fff;

--- a/app/views/box_requests/index.html.erb
+++ b/app/views/box_requests/index.html.erb
@@ -55,7 +55,7 @@
           <% if box_request.review_declined_by_ids.include?(current_user.id) %>
             (You declined)
           <% elsif box_request.is_reviewed %>
-            <span class="fa fa-check-circle"></span> [REVIEWED]
+            <span class="fas fa-check-circle"></span>
           <% elsif !box_request.reviewed_by_id.present? %>
             <%= link_to("Claim", box_request_claim_path(box_request), class: "btn btn-secondary") %>
             <%= link_to("Review", edit_box_request_path(box_request), class: "btn btn-secondary") %>
@@ -69,7 +69,7 @@
             <% if box.design_declined_by_ids.include?(current_user.id) %>
               (You declined)
             <% elsif box.is_designed %>
-              <span class="fa fa-check-circle"></span> [DESIGNED]
+              <span class="fas fa-check-circle"></span>
             <% elsif box_request.is_reviewed && !box.designed_by_id.present? %>
               <%= link_to("Claim", box_design_claim_path(box_id: box), class: "btn btn-secondary") %>
               <%= link_to("Design", box_design_new_path(box_id: box), class: "btn btn-secondary") %>
@@ -83,7 +83,7 @@
             <% if box.research_declined_by_ids.include?(current_user.id) %>
               (You declined)
             <% elsif box.is_researched %>
-              <span class="fa fa-check-circle"></span> [RESEARCHED]
+              <span class="fas fa-check-circle"></span>
             <% elsif box.is_designed && !box.researched_by_id.present? %>
               <%= link_to("Claim", box_research_claim_path(box_id: box), class: "btn btn-secondary") %>
               <%= link_to("Research", box_research_new_path(box_id: box), class: "btn btn-secondary") %>
@@ -99,7 +99,7 @@
             <% if box.assembly_declined_by_ids.include?(current_user.id) %>
               (You declined)
             <% elsif box.is_assembled %>
-              <span class="fa fa-check-circle"></span> [PACKAGED]
+              <span class="fas fa-check-circle"></span>
             <% elsif box.is_researched && !box.assembled_by_id.present? %>
               <%= link_to("Claim", box_assembly_claim_path(box_id: box), class: "btn btn-secondary") %>
               <%= link_to("Package", box_assembly_new_path(box_id: box), class: "btn btn-secondary") %>
@@ -113,7 +113,7 @@
             <% if box.shipping_declined_by_ids.include?(current_user.id) %>
               (You declined)
             <% elsif box.is_shipped %>
-              <span class="fa fa-check-circle"></span> [SHIPPED]
+              <span class="fas fa-check-circle"></span>
             <% elsif box.is_assembled && !box.shipped_by_id.present? %>
               <%= link_to("Claim", box_shipment_claim_path(box_id: box), class: "btn btn-secondary") %>
               <%= link_to("Ship", box_shipment_new_path(box_id: box), class: "btn btn-secondary") %>
@@ -127,7 +127,7 @@
             <% if box.followup_declined_by_ids.include?(current_user.id) %>
               (You declined)
             <% elsif box.is_followed_up %>
-              <span class="fa fa-check-circle"></span> [FOLLOWED-UP]
+              <span class="fas fa-check-circle"></span>
             <% elsif box.is_shipped && !box.followed_up_by.present? %>
               <%= link_to("Claim", box_follow_up_claim_path(box_id: box), class: "btn btn-secondary") %>
               <%= link_to("Followup", box_follow_up_new_path(box_id: box), class: "btn btn-secondary") %>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@babel/plugin-proposal-export-default-from": "^7.5.2",
     "@babel/preset-react": "^7.0.0",
+    "@fortawesome/fontawesome-free": "^5.11.2",
     "@rails/activestorage": "^6.0.0-alpha",
     "@rails/ujs": "^6.0.0-alpha",
     "@rails/webpacker": "^4.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -753,6 +753,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@fortawesome/fontawesome-free@^5.11.2":
+  version "5.11.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.11.2.tgz#8644bc25b19475779a7b7c1fc104bc0a794f4465"
+  integrity sha512-XiUPoS79r1G7PcpnNtq85TJ7inJWe0v+b5oZJZKb0pGHNIV6+UiNeQWiFGmuQ0aj7GEhnD/v9iqxIsjuRKtEnQ==
+
 "@rails/activestorage@^6.0.0-alpha":
   version "6.0.0-alpha"
   resolved "https://registry.yarnpkg.com/@rails/activestorage/-/activestorage-6.0.0-alpha.tgz#6eb6c0f49bcaa4ad68fcd13a750b9a17f76f086f"


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again
# Checklist:
- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
-->

Resolves #280  <!--fill issue number-->

### Description

- Adds `fontawesome` icons to styles
- Replaces status message on the `box_requests` page with a `check-mark`

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?

List any dependencies that are required for this change. (gems, js libraries, etc.)
Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Manually tested this, screenshot attached.
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Do we need to do anything else to verify your changes?
If so, provide instructions (including any relevant configuration) so that
we can reproduce? -->

### Screenshots

<!--Optional. Delete if not relevant.
Include screenshots (before / after) for style changes, highlight
edited element.-->
<img width="1280" alt="Screen Shot 2019-10-11 at 10 39 13 AM" src="https://user-images.githubusercontent.com/3170078/66660563-7308c880-ec13-11e9-8031-c7ee6b9efb70.png">
