### PR TITLE
Make use of :county field in public forms

### DIFF
--- a/app/controllers/box_request_triage_controller.rb
+++ b/app/controllers/box_request_triage_controller.rb
@@ -17,7 +17,8 @@ class BoxRequestTriageController < ApplicationController
      :street_address,
      :city,
      :state,
-     :zip
+     :zip,
+     :county
      ].each do |requester_attribute|
       requester.assign_attributes(requester_attribute => @payload[requester_attribute])
     end

--- a/app/controllers/volunteer_application_controller.rb
+++ b/app/controllers/volunteer_application_controller.rb
@@ -17,6 +17,7 @@ class VolunteerApplicationController < ApplicationController
      :city,
      :state,
      :zip,
+     :county,
      :marketing_vector,
      :why_volunteer
    ].each do |volunteer_attribute|

--- a/spec/controllers/box_request_triage_controller_spec.rb
+++ b/spec/controllers/box_request_triage_controller_spec.rb
@@ -38,15 +38,16 @@ RSpec.describe BoxRequestTriageController, type: :controller do
       expect(response.successful?).to be_falsey
     end
 
-    it "will save an email address" do
-
+    it "will save a Requester" do
       expected_email = test_data[:email]
+      expected_county= test_data[:county]
 
       post :create, :params => { :boxRequest => test_data }
 
       requester = Requester.last
 
       expect(requester.email).to eql(expected_email)
+      expect(requester.county).to eql(expected_county)
     end
 
     it "will create a BoxRequest" do

--- a/spec/controllers/box_request_triage_controller_spec.rb
+++ b/spec/controllers/box_request_triage_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe BoxRequestTriageController, type: :controller do
+  let!(:user) { FactoryBot.create(:user) }
+
   let(:test_data) {
     {
       city: Faker::Address.city,
@@ -24,7 +26,8 @@ RSpec.describe BoxRequestTriageController, type: :controller do
       state: Faker::Address.state,
       street_address: Faker::Address.street_address,
       summary: "sample summary",
-      zip: Faker::Address.zip
+      zip: Faker::Address.zip,
+      abuse_types: ["emotional"]
     }
   }
 

--- a/spec/controllers/volunteer_application_controller_spec.rb
+++ b/spec/controllers/volunteer_application_controller_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe VolunteerApplicationController, type: :controller do
     it "will create a volunteer" do
       expected_first_name = test_data[:first_name]
       expected_why_volunteer = test_data[:why_volunteer]
+      expected_county = test_data[:county]
       expected_ok_to_mail = test_data[:ok_to_mail]
       expected_ok_to_call = false # Should set default
       post :create, :params => { :volunteerApplication => test_data }
@@ -37,6 +38,7 @@ RSpec.describe VolunteerApplicationController, type: :controller do
 
       expect(volunteer.first_name).to eql(expected_first_name)
       expect(volunteer.why_volunteer).to eql(expected_why_volunteer)
+      expect(volunteer.county).to eql(expected_county)
       expect(volunteer.ok_to_mail).to eql(expected_ok_to_mail)
       expect(volunteer.ok_to_call).to eql(expected_ok_to_call)
     end


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/voices-of-consent/issues/284

### Description

- This PR updates the `create` endpoints in both BoxTriageController and VolunteerApplicationController to use the :county param
- This PR also fixes the test failures for `box_triage_controller_spec.rb`

### Type of change

- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Added assertions in RSpec tests