### PR TITLE
Remove cached_quantity from inventory_tally. No longer using that field.

### DIFF
--- a/app/models/inventory_adjustment.rb
+++ b/app/models/inventory_adjustment.rb
@@ -4,14 +4,5 @@ class InventoryAdjustment < ApplicationRecord
   belongs_to :box_item, optional: true
 
   validates :inventory_tally, presence: true
-  before_save :adjust_cached_inventory_quantity
-
-  def adjust_cached_inventory_quantity
-    self.tally_quantity_start = self.inventory_tally.cached_quantity.to_i
-    self.tally_quantity_end = self.tally_quantity_start + self.adjustment_quantity.to_i
-
-    # TODO: need to decide how to handle self.tally_quantity_end < 0
-    self.inventory_tally.update_attribute(:cached_quantity, self.tally_quantity_end)
-  end
 
 end

--- a/notes/database-diagram.dot
+++ b/notes/database-diagram.dot
@@ -208,7 +208,7 @@ digraph G {
                     purchase_id:references (optional)\n
                     box_item_id:references (optional)\n
                     total_cost:MONEY (optional)\n
-                    adjustment_quantity:int (positive or negative count, which \nchanges inventory_tally#cached_quantity)\n
+                    adjustment_quantity:int (positive or negative count)\n
 
                     }"]
     User [

--- a/spec/views/inventory_tallies/new.html.erb_spec.rb
+++ b/spec/views/inventory_tallies/new.html.erb_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe "inventory_tallies/new", type: :view do
 
       assert_select "input[name=?]", "inventory_tally[additional_location_info]"
 
-      assert_select "input[name=?]", "inventory_tally[cached_quantity]"
-
       assert_select "select[name=?]", "inventory_tally[inventory_type_id]"
 
       assert_select "select[name=?]", "inventory_tally[storage_location_id]"

--- a/spec/views/inventory_tallies/show.html.erb_spec.rb
+++ b/spec/views/inventory_tallies/show.html.erb_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe "inventory_tallies/show", type: :view do
       :additional_location_info => "Additional Location Info",
       :inventory_type => nil,
       :storage_location => nil,
-      :cached_quantity => 2,
       :inventory_type => create(:inventory_type),
       :storage_location => create(:location)
     )


### PR DESCRIPTION
InventoryTally#cached_quantity was a field we were using initially, but removed it to simplify the design. These got reintroduced when merging the fix-more-tests branch.