### PR TITLE
Add decline actions/methods for box lifecycle phases

### DIFF
--- a/app/controllers/box_assembly_controller.rb
+++ b/app/controllers/box_assembly_controller.rb
@@ -27,6 +27,25 @@ class BoxAssemblyController < ApplicationController
     end
   end
 
+  def decline
+    @box = request_review_scope.find(params[:box_id])
+    if @box.assembled_by != current_user
+
+      respond_to do |format|
+        if @box.decline_assembly!
+          format.html { redirect_to box_request_decline_thank_you_path(id: @box.box_request, phase: "assembly") }
+          format.json { render :show, status: :ok, location: @box }
+        else
+
+          format.html { redirect_to root_path, alert: 'Box assembly decline failed.' }
+          format.json { render :show, status: :ok, location: @box }
+        end
+      end
+    else
+      redirect_to edit_box_path(@box), notice: "You previously claimed assembly of this Box"
+    end
+  end
+
   def complete
     @box = box_claim_scope.find(params[:box_id])
 

--- a/app/controllers/box_design_controller.rb
+++ b/app/controllers/box_design_controller.rb
@@ -27,6 +27,25 @@ class BoxDesignController < ApplicationController
     end
   end
 
+  def decline
+    @box = request_review_scope.find(params[:box_id])
+    if @box.designed_by != current_user
+
+      respond_to do |format|
+        if @box.decline_design!
+          format.html { redirect_to box_request_decline_thank_you_path(id: @box.box_request, phase: "design") }
+          format.json { render :show, status: :ok, location: @box }
+        else
+
+          format.html { redirect_to root_path, alert: 'Box design decline failed.' }
+          format.json { render :show, status: :ok, location: @box }
+        end
+      end
+    else
+      redirect_to edit_box_path(@box), notice: "You previously claimed design of this Box"
+    end
+  end
+
   def complete
     @box = box_claim_scope.find(params[:box_id])
 

--- a/app/controllers/box_follow_up_controller.rb
+++ b/app/controllers/box_follow_up_controller.rb
@@ -28,6 +28,25 @@ class BoxFollowUpController < ApplicationController
     end
   end
 
+  def decline
+    @box = request_review_scope.find(params[:box_id])
+    if @box.followed_up_by != current_user
+
+      respond_to do |format|
+        if @box.decline_follow_up!
+          format.html { redirect_to box_request_decline_thank_you_path(id: @box.box_request, phase: "follow_up") }
+          format.json { render :show, status: :ok, location: @box }
+        else
+
+          format.html { redirect_to root_path, alert: 'Box follow_up decline failed.' }
+          format.json { render :show, status: :ok, location: @box }
+        end
+      end
+    else
+      redirect_to edit_box_path(@box), notice: "You previously claimed follow_up of this Box"
+    end
+  end
+
   def complete
     @box = box_claim_scope.find(params[:box_id])
 

--- a/app/controllers/box_requests_controller.rb
+++ b/app/controllers/box_requests_controller.rb
@@ -90,7 +90,7 @@ class BoxRequestsController < ApplicationController
 
       respond_to do |format|
         if @box_request.decline_review!
-          format.html { redirect_to box_request_decline_thank_you_path }
+          format.html { redirect_to box_request_decline_thank_you_path(id: @box_request, phase: "review") }
           format.json { render :show, status: :ok, location: @box_request }
         else
 

--- a/app/controllers/box_research_controller.rb
+++ b/app/controllers/box_research_controller.rb
@@ -29,6 +29,25 @@ class BoxResearchController < ApplicationController
     end
   end
 
+  def decline
+    @box = request_review_scope.find(params[:box_id])
+    if @box.researched_by != current_user
+
+      respond_to do |format|
+        if @box.decline_research!
+          format.html { redirect_to box_request_decline_thank_you_path(id: @box.box_request, phase: "research") }
+          format.json { render :show, status: :ok, location: @box }
+        else
+
+          format.html { redirect_to root_path, alert: 'Box research decline failed.' }
+          format.json { render :show, status: :ok, location: @box }
+        end
+      end
+    else
+      redirect_to edit_box_path(@box), notice: "You previously claimed research of this Box"
+    end
+  end
+
   def complete
     @box = box_claim_scope.find(params[:box_id])
 

--- a/app/controllers/box_shipment_controller.rb
+++ b/app/controllers/box_shipment_controller.rb
@@ -28,6 +28,25 @@ class BoxShipmentController < ApplicationController
     end
   end
 
+  def decline
+    @box = request_review_scope.find(params[:box_id])
+    if @box.shipped_by != current_user
+
+      respond_to do |format|
+        if @box.decline_shipping!
+          format.html { redirect_to box_request_decline_thank_you_path(id: @box.box_request, phase: "shipping") }
+          format.json { render :show, status: :ok, location: @box }
+        else
+
+          format.html { redirect_to root_path, alert: 'Box shipping decline failed.' }
+          format.json { render :show, status: :ok, location: @box }
+        end
+      end
+    else
+      redirect_to edit_box_path(@box), notice: "You previously claimed shipping of this Box"
+    end
+  end
+
   def complete
     @box = box_claim_scope.find(params[:box_id])
 

--- a/app/models/box.rb
+++ b/app/models/box.rb
@@ -235,6 +235,31 @@ class Box < ApplicationRecord
       puts "Changed from #{aasm.from_state} to #{aasm.to_state} (event: #{aasm.current_event})"
     end
 
+    def decline_design!
+      self.design_declined_by_ids << current_user.id
+      self.save!
+    end
+
+    def decline_research!
+      self.research_declined_by_ids << current_user.id
+      self.save!
+    end
+
+    def decline_assembly!
+      self.assembly_declined_by_ids << current_user.id
+      self.save!
+    end
+
+    def decline_shipping!
+      self.shipping_declined_by_ids << current_user.id
+      self.save!
+    end
+
+    def decline_follow_up!
+      self.followup_declined_by_ids << current_user.id
+      self.save!
+    end
+
     def create_core_box_items!
       box_request.box_request_abuse_types.each do |box_request_abuse_type|
         CoreBoxItem.where(abuse_type: box_request_abuse_type.abuse_type).each do |core_box_item|


### PR DESCRIPTION
- We have the routes, but needed endpoints and instance methods to track declines from autoemails
- Decline endpoint:
  - Marks box/box_request as declined, and adds the user's id to the relevant array that stores every decline
  - Routes to a generic box_request_decline_thank_you path that takes box_request_id and phase (e.g. design, shipping, assembly, etc)
  - Routes to the edit_box_path(@box) if for some reason the user has already claimed (accepted) a task. (Prob should send them to the relevant /new action instead of edit...)

- Needs tests!