### PR TITLE
Add researched_at to box_items table, then update it when appropriate

### DIFF
--- a/app/models/box.rb
+++ b/app/models/box.rb
@@ -199,7 +199,7 @@ class Box < ApplicationRecord
         research_status = []
         box_items.each do |box_item|
           if box_item.requires_research
-            research_status << box_item.researched_by_id.present? ? true : false # TODO - add researched_at to BoxItem
+            research_status << box_item.researched_by_id.present? && box_item.researched_at ? true : false
           end
         end
         research_status.all?

--- a/app/models/box.rb
+++ b/app/models/box.rb
@@ -132,7 +132,8 @@ class Box < ApplicationRecord
 
     def mark_box_items_as_researched! # TODO - remove this as always happening!
       box_items.each do |box_item|
-        box_item.update_attributes(researched_by_id: researched_by_id || designed_by_id)
+        box_item.update_attributes(researched_at: Time.now,
+                                   researched_by_id: researched_by_id || designed_by_id)
       end
     end
 

--- a/db/migrate/20191012012740_add_researched_at_to_box_items.rb
+++ b/db/migrate/20191012012740_add_researched_at_to_box_items.rb
@@ -1,0 +1,5 @@
+class AddResearchedAtToBoxItems < ActiveRecord::Migration[5.2]
+  def change
+  	add_column :box_items, :researched_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_10_204858) do
+ActiveRecord::Schema.define(version: 2019_10_12_012740) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 2019_10_10_204858) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "inventory_type_id", null: false
+    t.datetime "researched_at"
     t.index ["box_id"], name: "index_box_items_on_box_id"
     t.index ["created_by_id"], name: "index_box_items_on_created_by_id"
     t.index ["inventory_type_id"], name: "index_box_items_on_inventory_type_id"

--- a/spec/models/box_spec.rb
+++ b/spec/models/box_spec.rb
@@ -89,6 +89,9 @@ RSpec.describe Box, :type => :model do
     end
 
     it "transitions from research_in_progress to researched" do
+      @time_now = Time.parse("Oct 11 2019")
+      Time.stub(:now).and_return(@time_now)
+
       box_request_1.reviewed_by_id = reviewer.id;
       box_request_1.save
       box_request_1.claim_review!
@@ -106,6 +109,7 @@ RSpec.describe Box, :type => :model do
       box.claim_research!
       box.mark_box_items_as_researched!
       expect(box).to transition_from(:research_in_progress).to(:researched).on_event(:complete_research)
+      expect(box.researched_at).to eq(@time_now)
     end
 
     it "transitions from researched to assembly in progress" do


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again
# Checklist:
- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
-->

Resolves #303

### Description

- Adds a `researched_at` column to the `box_items` table
- Updates `Box#mark_box_items_as_researched!` to update the box's `researched_at` column with `Time.now` when called
- Updates `Box#box_item_research_completed?` to use the value of `researched_at` alongside `researched_by` to determine whether research is indeed completed
- Adds an expectation to an existing test to check that `researched_at` is indeed being updated
- Did not add any additional tests for `Box#box_item_research_completed?` as the changes made to that method did not break any existing tests of Box model methods dependent on it

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?

List any dependencies that are required for this change. (gems, js libraries, etc.)
Include anything else we should know about. -->

### Type of change

- New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- Rspec tests - these changes and test updates do not introduce any new failures to the rspec tests