### PR TITLE
Fix specs so rspec can run!

### DIFF
--- a/app/models/box.rb
+++ b/app/models/box.rb
@@ -278,6 +278,7 @@ class Box < ApplicationRecord
 
     def send_assembly_solicitation_email!
       AutoEmailHandler.new("volunteer", self, self.researched_by)
+    end
 
     def send_shipping_solicitation_email!
       AutoEmailHandler.new("volunteer", self, self.assembled_by)

--- a/spec/models/box_spec.rb
+++ b/spec/models/box_spec.rb
@@ -304,6 +304,7 @@ RSpec.describe Box, :type => :model do
       allow(AutoEmailHandler).to receive(:new)
 
       box.send_assembly_solicitation_email!
+    end
   end
 
   describe Box, "#send_shipping_solicitation_email!" do


### PR DESCRIPTION
### Description

Rspec can't run cause 2 blocks of code don't have the necessary `end`, breaking files and not allowing ruby to parse them.