### PR TITLE
Resolves #329: Removed duplicate 'location_type' field from location form

### DIFF
--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -17,7 +17,6 @@
       <%= f.input :city %>
       <%= f.input :state %>
       <%= f.input :zip %>
-      <%= f.input :location_type %>
   </div>
 
   <div class="form-group row mb-0" style="margin: 2rem 0">


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again
# Checklist:
- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
-->

Resolves #329 

### Description

Removed duplicate 'location_type' field from location form

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?

List any dependencies that are required for this change. (gems, js libraries, etc.)
Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Simple single line delete from code.

<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Do we need to do anything else to verify your changes?
If so, provide instructions (including any relevant configuration) so that
we can reproduce? -->

### Screenshots

<!--Optional. Delete if not relevant.
Include screenshots (before / after) for style changes, highlight
edited element.-->
