### PR TITLE
BoxDesign React component draws InventoryTypes from the database instead of mock

### DIFF
--- a/app/javascript/src/components/box-design-form/BoxDesignForm.jsx
+++ b/app/javascript/src/components/box-design-form/BoxDesignForm.jsx
@@ -3,8 +3,6 @@ import ItemPicker from '../item-picker'
 import './BoxDesignForm.scss';
 import InventoryAutosuggest from '../inventory-autosuggest';
 import { keyHandler } from '../../utilities';
-import { itemTypes as mockItemTypes } from '../../mocks/mockData';
-
 
 
 const BoxDesign = () => {
@@ -13,8 +11,13 @@ const BoxDesign = () => {
   const [searchInput, updateSearchInput] = useState("")
 
   useEffect(() => {
-    // Mock API call to return available inventory items.
-    updateAvailableItems(mockItemTypes)
+    // API call to return available inventory items.
+    fetch('/inventory_types.json')
+      .then(response => response.json())
+      .then((data) => {
+        const fetchedItemTypes = data.map(({ name }) => name)
+        updateAvailableItems(fetchedItemTypes)
+      });
   }, [])
 
   const updateItemCount = (targetIndex) => (newValue) => {

--- a/app/javascript/src/mocks/mockData.js
+++ b/app/javascript/src/mocks/mockData.js
@@ -1,18 +1,3 @@
-export const itemTypes = [
-    'Toothbrush',
-    'Soap',
-    'Glitter',
-    'Bath Bomb',
-    'Shoes',
-    'Socks',
-    'Silverware',
-    'TV',
-    'Sunglasses',
-    'Peanuts',
-    'Hairbrush',
-    'Bible',
-  ];
-
 export const unassembledBoxItems = [
   {
     type: 'Toothbrush',

--- a/app/views/inventory_types/_inventory_type.json.jbuilder
+++ b/app/views/inventory_types/_inventory_type.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! inventory_type, :id, :name, :description, :created_at, :updated_at
+json.extract! inventory_type, :id, :name, :description
 json.url inventory_type_url(inventory_type, format: :json)

--- a/spec/controllers/inventory_types_controller_spec.rb
+++ b/spec/controllers/inventory_types_controller_spec.rb
@@ -25,12 +25,16 @@ require 'rails_helper'
 
 RSpec.describe InventoryTypesController, type: :controller do
   has_authenticated_user
+  render_views
 
   # This should return the minimal set of attributes required to create a valid
   # InventoryType. As you add validations to InventoryType, be sure to
   # adjust the attributes here as well.
   let(:valid_attributes) {
-    skip("Add a hash of attributes valid for your model")
+    {
+      name: Faker::House.furniture.titleize,
+      description: Faker::Lorem.sentence
+    }
   }
 
   let(:invalid_attributes) {
@@ -47,6 +51,16 @@ RSpec.describe InventoryTypesController, type: :controller do
       InventoryType.create! valid_attributes
       get :index, params: {}, session: valid_session
       expect(response).to be_successful
+    end
+  end
+
+  describe 'GET #index as :json' do
+    it 'returns a success response' do
+      InventoryType.create! valid_attributes
+      get :index, params: { format: :json }
+      expect(response).to be_successful
+      expect(JSON.parse(response.body).length).to eq(1)
+      expect(JSON.parse(response.body)[0]).to have_key('name')
     end
   end
 

--- a/spec/factories/inventory_type.rb
+++ b/spec/factories/inventory_type.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :inventory_type do
-    name { "MyString" }
-    description { "MyString" }
+    name { Faker::House.furniture.titleize }
+    description { Faker::Lorem.sentence }
   end
 end


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again
# Checklist:
- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
-->

Resolves #288  <!--fill issue number-->

### Description

Previously, the BoxDesign React component got the list of possible InventoryTypes from a mock data file. Now, it gets it from the JSON API at `/inventory_types.json`

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?

List any dependencies that are required for this change. (gems, js libraries, etc.)
Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->
- New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Added a spec at `spec/controllers/inventory_types_controller_spec.rb:53` to verify that the JSON endpoint returns valid

<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Do we need to do anything else to verify your changes?
If so, provide instructions (including any relevant configuration) so that
we can reproduce? -->

