### PR TITLE
[BUGFIX] Locations#new should not throw error for location_type

### DIFF
--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -11,7 +11,7 @@
   <%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
 
   <div class="form-inputs container">
-      <%= f.input :location_type, as: :select, collection: Location.location_types, label: "Location type" %>
+      <%= f.input :location_type, as: :select, collection: Location.location_types.keys, label: "Location type" %>
       <%= f.input :name %>
       <%= f.input :street_address %>
       <%= f.input :city %>


### PR DESCRIPTION
Resolves #359 AND #358 

### Description
Should use `.keys` when mapping `select` to `location_type` hash
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?

List any dependencies that are required for this change. (gems, js libraries, etc.)
Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Manually tested on local and checked db for new records created.
<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Do we need to do anything else to verify your changes?
If so, provide instructions (including any relevant configuration) so that
we can reproduce? -->

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/42528623/66884982-7b8f4380-f005-11e9-80f6-203ec6a7ea99.png)

After:
![image](https://user-images.githubusercontent.com/42528623/66885037-aa0d1e80-f005-11e9-9398-5c3985207d45.png)

Edit page also now shows value from activerecord:
![image](https://user-images.githubusercontent.com/42528623/66886137-002f9100-f009-11e9-8fa2-276b93bad520.png)

<!--Optional. Delete if not relevant.
Include screenshots (before / after) for style changes, highlight
edited element.-->
