### PR TITLE
[Feature] Show inventory list in alphabetical order based on name

### DIFF
--- a/app/controllers/inventory_types_controller.rb
+++ b/app/controllers/inventory_types_controller.rb
@@ -4,7 +4,7 @@ class InventoryTypesController < ApplicationController
   # GET /inventory_types
   # GET /inventory_types.json
   def index
-    @inventory_types = InventoryType.all
+    @inventory_types = InventoryType.all.sort_by { |inventory_type| inventory_type.name }
   end
 
   # GET /inventory_types/1

--- a/app/controllers/inventory_types_controller.rb
+++ b/app/controllers/inventory_types_controller.rb
@@ -5,7 +5,7 @@ class InventoryTypesController < ApplicationController
   # GET /inventory_types.json
   # Returns alphabetically ordered list of inventory types based on name
   def index
-    @inventory_types = InventoryType.all.sort_by { |inventory_type| inventory_type.name }
+    @inventory_types = InventoryType.all.sort_by(&:name)
   end
 
   # GET /inventory_types/1

--- a/app/controllers/inventory_types_controller.rb
+++ b/app/controllers/inventory_types_controller.rb
@@ -3,6 +3,7 @@ class InventoryTypesController < ApplicationController
 
   # GET /inventory_types
   # GET /inventory_types.json
+  # Returns alphabetically ordered list of inventory types based on name
   def index
     @inventory_types = InventoryType.all.sort_by { |inventory_type| inventory_type.name }
   end

--- a/spec/controllers/inventory_types_controller_spec.rb
+++ b/spec/controllers/inventory_types_controller_spec.rb
@@ -73,14 +73,15 @@ RSpec.describe InventoryTypesController, type: :controller do
 
       before do
         unordered_name_list.each do |inventory_name|
-          InventoryType.create! ({ name: inventory_name, description: Faker::Lorem.sentence })
+          options = { name: inventory_name, description: Faker::Lorem.sentence }
+          InventoryType.create! options
         end
       end
 
       it 'returns the inventory type list in alphabetical order of name' do
         get :index, params: { format: :json }
-        name_list_response = JSON.parse(response.body).map { |inventory| inventory['name'] }
-        expect(name_list_response).to eql(ordered_name_list)
+        types = JSON.parse(response.body).map { |inventory| inventory['name'] }
+        expect(types).to eql(ordered_name_list)
       end
     end
   end

--- a/spec/controllers/inventory_types_controller_spec.rb
+++ b/spec/controllers/inventory_types_controller_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe InventoryTypesController, type: :controller do
   # InventoryTypesController. Be sure to keep this updated too.
   let(:valid_session) { {} }
 
-  describe "GET #index" do
-    it "returns a success response" do
+  describe 'GET #index' do
+    it 'returns a success response' do
       InventoryType.create! valid_attributes
       get :index, params: {}, session: valid_session
       expect(response).to be_successful

--- a/spec/controllers/inventory_types_controller_spec.rb
+++ b/spec/controllers/inventory_types_controller_spec.rb
@@ -62,6 +62,27 @@ RSpec.describe InventoryTypesController, type: :controller do
       expect(JSON.parse(response.body).length).to eq(1)
       expect(JSON.parse(response.body)[0]).to have_key('name')
     end
+
+    context 'when there are multiple records for the inventory type' do
+      let(:unordered_name_list) do
+        %w[Sanitary\ Pads Blankets First\ Aid\ Kit]
+      end
+      let(:ordered_name_list) do
+        %w[Blankets First\ Aid\ Kit Sanitary\ Pads]
+      end
+
+      before do
+        unordered_name_list.each do |inventory_name|
+          InventoryType.create! ({ name: inventory_name, description: Faker::Lorem.sentence })
+        end
+      end
+
+      it 'returns the inventory type list in alphabetical order of name' do
+        get :index, params: { format: :json }
+        name_list_response = JSON.parse(response.body).map { |inventory| inventory['name'] }
+        expect(name_list_response).to eql(ordered_name_list)
+      end
+    end
   end
 
   describe "GET #show" do


### PR DESCRIPTION
Resolves #378 

### Description
The list of inventory types in the Design Box dropdown is now listed alphabetically based on name. This resolves the issue linked above.

### Type of change
- New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
1. Test coverage for the `GET` requests for `inventory_types` and `inventory_types.json` has been added to validate the returned results are in alphabetical order.

2. Manually tested the changes from UI in the inventory dropdown list. Steps to reproduce:
- Click on the `Design` icon on the top of the interface. This will list the box requests.
- Click on `Review` on one of the box requests. Review the details and complete the box review.
- Now click on the `Design` button on the box request that we just reviewed.
- This will show us Box Design page. Click on the `Search Inventory` dropdown. It should show the list of inventory types in alphabetical order.

### Screenshots
![voice_of_consent](https://user-images.githubusercontent.com/10415283/67307157-c504f480-f517-11e9-86b0-41ac8578e401.gif)

<img width="1438" alt="Screen Shot 2019-10-22 at 10 02 53 PM" src="https://user-images.githubusercontent.com/10415283/67307243-ea91fe00-f517-11e9-9e0f-e40cbe4177b6.png">
