### PR TITLE
Fix typo in Box Design page

### DIFF
--- a/app/javascript/src/components/box-design-form/BoxDesignForm.jsx
+++ b/app/javascript/src/components/box-design-form/BoxDesignForm.jsx
@@ -102,7 +102,9 @@ const BoxDesign = () => {
                 <>
                   <p>The next step is:</p>
                   <h2>Assembly of Care Box</h2>
-                  <p>Thanks so much for your help. Please click the following button below if you are read to progress this box to the next step.</p>
+                  <p>Thanks so much for your help. Please click the following
+                     button below if you are ready to progress this box to the
+                     next step.</p>
                 </>
               )
             : 


### PR DESCRIPTION
Resolves #380 

### Description
In the design box page, once we select an item from the inventory dropdown, instructions about next steps is displayed with a thank you message. The message contains a typo where **ready** is misspelled as **read**. This has been addressed in this PR.

### Type of change
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- After this change, when the page is loaded following the steps mentioned in description, the message is displayed as:
```
Thanks so much for your help. Please click the following button below if you are ready to progress this box to the next step.
```

### Screenshots
<img width="1440" alt="Screen Shot 2019-10-22 at 11 16 00 PM" src="https://user-images.githubusercontent.com/10415283/67313129-292cb600-f522-11e9-9c07-4475b9d605fb.png">
