### PR TITLE
Update devise to 4.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem 'webpacker', '~> 4.x'
 gem 'aasm'
 
 # auth
-gem 'devise', '~> 4.6'
+gem 'devise', '>= 4.7.1'
 gem 'devise_invitable', '~> 2.0.0'
 
 gem 'pundit', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,11 +85,11 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
-    crass (1.0.4)
-    devise (4.6.2)
+    crass (1.0.5)
+    devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0, < 6.0)
+      railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
     devise_invitable (2.0.1)
@@ -120,7 +120,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.3.0)
+    loofah (2.3.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -282,6 +282,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-19
 
 DEPENDENCIES
   aasm
@@ -290,7 +291,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
   capybara (>= 2.15)
-  devise (~> 4.6)
+  devise (>= 4.7.1)
   devise_invitable (~> 2.0.0)
   factory_bot_rails
   faker


### PR DESCRIPTION
Resolves #240 

### Description
Updates devise gem to 4.7.1 to mitigate vulnerability issues.

### Type of change
- New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Locally tested authentication.