### PR TITLE
Add hover text to icon with aasm_state

### DIFF
--- a/app/views/box_requests/index.html.erb
+++ b/app/views/box_requests/index.html.erb
@@ -94,8 +94,7 @@
         </td>
         <td>
           <% if box %>
-            <%= box.box_items.count %> items
-            <%= box.aasm_state %>
+          <img src="https://voices-of-consent-static-images.s3.amazonaws.com/Packing+Stage.svg" title=<%= box.aasm_state %> >
             <% if box.assembly_declined_by_ids.include?(current_user.id) %>
               (You declined)
             <% elsif box.is_assembled %>

--- a/app/views/box_requests/index.html.erb
+++ b/app/views/box_requests/index.html.erb
@@ -94,7 +94,7 @@
         </td>
         <td>
           <% if box %>
-          <img src="https://voices-of-consent-static-images.s3.amazonaws.com/Packing+Stage.svg" title=<%= box.aasm_state %> >
+            <%= image_tag("https://voices-of-consent-static-images.s3.amazonaws.com/Packing+Stage.svg", :title => box.aasm_state)%>
             <% if box.assembly_declined_by_ids.include?(current_user.id) %>
               (You declined)
             <% elsif box.is_assembled %>


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again
# Checklist:
- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.
-->

Resolves #343  <!--fill issue number-->

### Description
Is just a change to add a hover text to package icon with the aasm_state of the box.

### Type of change

<!-- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested by view

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/30028621/67634280-85803480-f898-11e9-8e3b-a214d61e31f2.png)

After:
![image](https://user-images.githubusercontent.com/30028621/67634258-3b974e80-f898-11e9-8d3a-2034a4bcb6d9.png)

