### PR TITLE
Add dependent destroy to volunteer model for user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :invitable, :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable
 
-  belongs_to :volunteer
+  belongs_to :volunteer, dependent: :destroy
 
   has_one_attached :avatar
   has_many :user_permissions

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -3,10 +3,10 @@
 class Volunteer < ApplicationRecord
   include Messageable
   include Sendable
-  
+
   require 'csv'
 
-  has_one :user
+  has_one :user, dependent: :destroy
   belongs_to :university_location, class_name: 'Location', required: false
 
   validates :first_name, presence: true


### PR DESCRIPTION
Resolves #392 

### Description
This change includes the dependent: destroy option to the has_one user relation of the volunteer.rb model. With this, whenever a volunteer is destroyed from the volunteer table, the user associated will also be destroyed. 

### Type of change


- Bug fix (non-breaking change which fixes an issue)

