### PR TITLE
textarea switched to input on simpleform

### DIFF
--- a/app/views/inventory_tallies/_form.html.erb
+++ b/app/views/inventory_tallies/_form.html.erb
@@ -13,7 +13,10 @@
   <div class="form-inputs container">
       <%= f.association :inventory_type %>
       <%= f.association :storage_location, collection: Location.storage_unit %>
-      <%= f.input :additional_location_info %>
+      <%= f.input :additional_location_info,
+                  as: :text,
+                  input_html: {value: f.object.additional_location_info,
+                               rows: 2} %>
   </div>
 
   <div class="form-group row mb-0" style="margin: 2rem 0">

--- a/app/views/inventory_tallies/_form.html.erb
+++ b/app/views/inventory_tallies/_form.html.erb
@@ -13,7 +13,7 @@
   <div class="form-inputs container">
       <%= f.association :inventory_type %>
       <%= f.association :storage_location, collection: Location.storage_unit %>
-      <%= f.text_area :additional_location_info %>
+      <%= f.input :additional_location_info %>
   </div>
 
   <div class="form-group row mb-0" style="margin: 2rem 0">

--- a/spec/views/inventory_tallies/edit.html.erb_spec.rb
+++ b/spec/views/inventory_tallies/edit.html.erb_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "inventory_tallies/edit", type: :view do
 
     assert_select "form[action=?][method=?]", inventory_tally_path(@inventory_tally), "post" do
 
-      assert_select "input[name=?]", "inventory_tally[additional_location_info]"
+      assert_select "textarea[name=?]", "inventory_tally[additional_location_info]"
 
       assert_select "select[name=?]", "inventory_tally[inventory_type_id]"
 

--- a/spec/views/inventory_tallies/new.html.erb_spec.rb
+++ b/spec/views/inventory_tallies/new.html.erb_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "inventory_tallies/new", type: :view do
 
     assert_select "form[action=?][method=?]", inventory_tally_path(@inventory_tally), "post" do
 
-      assert_select "input[name=?]", "inventory_tally[additional_location_info]"
+      assert_select "textarea[name=?]", "inventory_tally[additional_location_info]"
 
       assert_select "select[name=?]", "inventory_tally[inventory_type_id]"
 


### PR DESCRIPTION
Resolves #395 

### Description

Changed from a textarea to an input type which fixed the failing tests.

### Type of change

- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

All Rspec tests are passing.
