### PR TITLE
Adding model validations for name and location_type to Location

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -6,6 +6,9 @@ class Location < ApplicationRecord
   has_many :volunteers, foreign_key: 'university_location_id',
                         dependent: :nullify
 
+  validates :name, presence: true
+  validates :location_type, presence: true
+
   enum location_type: {
     # Example types from ERD
     storage_unit: 0,

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe Location, type: :model do
     expect(Location.new(valid_attributes)).to be_valid
   end
 
+  it 'is invalid with invalid attributes' do
+    expect(Location.new(valid_attributes.without(:name))).to be_invalid
+  end
+
   it 'enforces location_type enum' do
     attributes = valid_attributes.merge(location_type: :solar_system)
     expect { Location.new(attributes) }.to raise_error ArgumentError

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -6,12 +6,18 @@ RSpec.describe Location, type: :model do
     city: 'Pittsburgh', state: 'PA', zip: 15260, location_type: :university }
   end
 
-  it 'is valid with valid attributes' do
-    expect(Location.new(valid_attributes)).to be_valid
+  context 'with invalid attributes' do
+    it 'is invalid without name' do
+      expect(Location.new(valid_attributes.without(:name))).to be_invalid
+    end
+
+    it 'is invalid without location_type' do
+      expect(Location.new(valid_attributes.without(:location_type))).to be_invalid
+    end
   end
 
-  it 'is invalid with invalid attributes' do
-    expect(Location.new(valid_attributes.without(:name))).to be_invalid
+  it 'is valid with valid attributes' do
+    expect(Location.new(valid_attributes)).to be_valid
   end
 
   it 'enforces location_type enum' do


### PR DESCRIPTION
Resolves #403 

### Description

This change introduces presence-based validations to `Location` on `name` and `location_type`. This is using the default activerecord validations for detecting presence. I've also added a new spec to `location_spec.rb` to validate the lack of validity in a record missing these attributes. 


### Type of change

- New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

This has been tested manually in rails console by creating Location records with invalid attributes and verifying that validations prevented the record from being persisted. In addition to this it is tested via an `Rspec` spec on the model.
