### PR TITLE
issue 411, adding Research button to navbar with existing icon

### DIFF
--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -14,9 +14,13 @@
     <img src="https://voices-of-consent-static-images.s3.amazonaws.com/Design+Stage.svg" title="Design">
     <span>Design</span>
   </a>
+  <a class="nav-icon" href="<%= box_requests_path %>">
+    <img src="https://voices-of-consent-static-images.s3.amazonaws.com/Packing+Stage.svg" title="Research">
+    <span>Research</span>
+  </a>
   <a class="nav-icon" href="/">
-    <img src="https://voices-of-consent-static-images.s3.amazonaws.com/Packing+Stage.svg" title="Packing">
-    <span>Packing</span>
+  <img src="https://voices-of-consent-static-images.s3.amazonaws.com/Packing+Stage.svg" title="Packing">
+  <span>Packing</span>
   </a>
   <a class="nav-icon" href="/">
     <img src="https://voices-of-consent-static-images.s3.amazonaws.com/Shipping+boc+redux.svg" title="Shipping">


### PR DESCRIPTION
Resolves #411 

### Description

Not sure that this involves any new added tests needed, please let me know.  Just adding Research to navbar right after Design, using the existing Packing .svg image as a placeholder for now, per discussion with Mae. 

- New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Just tested in browser

![image](https://user-images.githubusercontent.com/17362519/74696606-0fe10100-51c6-11ea-8379-91a6b0afe929.png)

