### PR TITLE
Add followed_up scope and dropdown option for filtering

### DIFF
--- a/app/models/box_request.rb
+++ b/app/models/box_request.rb
@@ -26,6 +26,7 @@ class BoxRequest < ApplicationRecord
   scope :shipped, ->(){ joins(:box).where("boxes.aasm_state = ?", "shipped") }
   scope :research_in_progress, ->(){ joins(:box).where("boxes.aasm_state = ?", "research_in_progress") }
   scope :researched, ->(){ joins(:box).where("boxes.aasm_state = ?", "researched") }
+  scope :followed_up, ->(){ joins(:box).where("boxes.aasm_state = ?", "followed_up") }
 
   aasm do
 

--- a/app/views/box_requests/index.html.erb
+++ b/app/views/box_requests/index.html.erb
@@ -23,6 +23,7 @@
                             :assembled,
                             :shipping_in_progress,
                             :shipped,
+                            :followed_up
                            ],
                            selected: params[:filter_by]),
                        include_blank: "-- Filter options --",


### PR DESCRIPTION
Resolves #410

### Description

- Adds the `followed_up` scope to `BoxRequest` model
- Add dropdown option for filtering BoxRequest by the `followed_up` state

### Type of change

- New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

I modified the state of a single BoxRequest by setting the state to `followed_up`. Then I proceeded to use the filters to try to filter them,

### Screenshots

<img width="822" alt="Screen Shot 2020-02-22 at 9 53 48 PM" src="https://user-images.githubusercontent.com/11335191/75102767-c70ebb00-55be-11ea-8260-382230159bf9.png">

