### PR TITLE
Add factorybot box traits

### DIFF
--- a/spec/factories/box.rb
+++ b/spec/factories/box.rb
@@ -1,5 +1,16 @@
 FactoryBot.define do
   factory :box do
     box_request
+
+    trait :is_designed do
+      designed_by {create(:user, :designer)}
+      designed_at { Time.now }
+      design_reviewed_by_id  {create(:user, :reviewer).id}
+      design_reviewed_at { Time.now }
+      #how to update state?
+    end
   end
 end
+
+
+#assembled_box = create(:box, :is_assembled), which also has/mimics the traits :is_designed, :is_researched, box_request#is_reviewed, etc, bc our /box_requests #index needs all the prior lifecycle phase to be true and all future lifecycle phases to be untrue to display correctly.

--- a/spec/factories/box.rb
+++ b/spec/factories/box.rb
@@ -2,15 +2,68 @@ FactoryBot.define do
   factory :box do
     box_request
 
-    trait :is_designed do
-      designed_by {create(:user, :designer)}
+    trait :reviewed do
+      box_request {(create(:box_request, :review_complete))}
+    end
+
+    trait :design_in_progress do 
+      reviewed
+      aasm_state { "design_in_progress"}
+      designed_by_id {create(:user, :designer).id}
       designed_at { Time.now }
       design_reviewed_by_id  {create(:user, :reviewer).id}
       design_reviewed_at { Time.now }
-      #how to update state?
     end
+
+    trait :designed do 
+      design_in_progress
+      aasm_state { "designed"}
+      box_items {create_list(:box_item, 1, :research_needed)}
+    end
+
+    trait :research_in_progress do 
+      designed
+      aasm_state {"research_in_progress"}
+      researched_by_id {create(:user, :researcher).id}
+    end
+
+    trait :researched do 
+      research_in_progress
+      aasm_state {"researched"}
+    end
+
+    trait :assembly_in_progress do 
+      researched
+      aasm_state {"assembly_in_progress"}
+      assembled_by_id {create(:user, :assembler).id}
+    end
+
+    trait :assembled do 
+      assembly_in_progress
+      aasm_state {"assembled"}
+    end
+
+    trait :shipping_in_progress do 
+      assembled
+      aasm_state {"shipping_in_progress"}
+      shipped_by_id {create(:user, :shipper).id}
+    end
+
+    trait :shipped do 
+      shipping_in_progress
+      aasm_state {"shipped"}
+    end
+
+    trait :follow_up_in_progress do 
+      shipping_in_progress
+      aasm_state {"follow_up_in_progress"}
+      followed_up_by_id {create(:user, :follow_upper).id}
+    end
+
+    trait :followed_up do 
+      follow_up_in_progress
+      aasm_state {"followed_up"}
+    end
+
   end
 end
-
-
-#assembled_box = create(:box, :is_assembled), which also has/mimics the traits :is_designed, :is_researched, box_request#is_reviewed, etc, bc our /box_requests #index needs all the prior lifecycle phase to be true and all future lifecycle phases to be untrue to display correctly.

--- a/spec/factories/box.rb
+++ b/spec/factories/box.rb
@@ -1,22 +1,24 @@
 FactoryBot.define do
   factory :box do
+    
     box_request
 
     trait :reviewed do
-      box_request {(create(:box_request, :review_complete))}
+      box_request {(create(:box_request, :reviewed))}
     end
 
     trait :design_in_progress do 
+      after(:create) { |box| box.check_has_box_items }
       reviewed
       aasm_state { "design_in_progress"}
       designed_by_id {create(:user, :designer).id}
-      designed_at { Time.now }
       design_reviewed_by_id  {create(:user, :reviewer).id}
       design_reviewed_at { Time.now }
     end
-
+    
     trait :designed do 
       design_in_progress
+      designed_at { Time.now }
       aasm_state { "designed"}
       box_items {create_list(:box_item, 1, :research_needed)}
     end
@@ -29,6 +31,7 @@ FactoryBot.define do
 
     trait :researched do 
       research_in_progress
+      after(:build) { |box| box.mark_box_items_as_researched! }
       aasm_state {"researched"}
     end
 
@@ -41,6 +44,7 @@ FactoryBot.define do
     trait :assembled do 
       assembly_in_progress
       aasm_state {"assembled"}
+      assembled_at { Time.now }
     end
 
     trait :shipping_in_progress do 
@@ -52,6 +56,7 @@ FactoryBot.define do
     trait :shipped do 
       shipping_in_progress
       aasm_state {"shipped"}
+      shipped_at { Time.now }
     end
 
     trait :follow_up_in_progress do 
@@ -63,6 +68,7 @@ FactoryBot.define do
     trait :followed_up do 
       follow_up_in_progress
       aasm_state {"followed_up"}
+      followed_up_at { Time.now }
     end
 
   end

--- a/spec/factories/box.rb
+++ b/spec/factories/box.rb
@@ -15,8 +15,15 @@ FactoryBot.define do
       design_reviewed_by_id  {create(:user, :reviewer).id}
       design_reviewed_at { Time.now }
     end
+
+    trait :designed_no_research do 
+      design_in_progress
+      designed_at { Time.now }
+      aasm_state { "designed"}
+      box_items {create_list(:box_item, 1, :no_research_needed)}
+    end
     
-    trait :designed do 
+    trait :designed_needs_research do 
       design_in_progress
       designed_at { Time.now }
       aasm_state { "designed"}
@@ -24,7 +31,7 @@ FactoryBot.define do
     end
 
     trait :research_in_progress do 
-      designed
+      designed_needs_research
       aasm_state {"research_in_progress"}
       researched_by_id {create(:user, :researcher).id}
     end

--- a/spec/factories/box_item.rb
+++ b/spec/factories/box_item.rb
@@ -4,5 +4,14 @@ FactoryBot.define do
     inventory_type
     created_by
     updated_by
+
+    trait :research_needed do
+      inventory_type {create(:inventory_type, :needs_research)}
+    end
+
+    trait :no_research_needed do
+      inventory_type {create(:inventory_type, :no_research)}
+    end
+    
   end
 end

--- a/spec/factories/box_item.rb
+++ b/spec/factories/box_item.rb
@@ -8,9 +8,14 @@ FactoryBot.define do
     trait :research_needed do
       inventory_type {create(:inventory_type, :needs_research)}
     end
-
+ 
     trait :no_research_needed do
       inventory_type {create(:inventory_type, :no_research)}
+    end
+
+    trait :researched do 
+      research_needed
+      researched_at { Time.now }
     end
     
   end

--- a/spec/factories/box_request.rb
+++ b/spec/factories/box_request.rb
@@ -2,6 +2,19 @@ FactoryBot.define do
   factory :box_request, aliases: [:messageable] do
     requester
 
+    trait :has_reviewer do
+      reviewed_by_id {create(:user, :reviewer).id}
+      reviewed_at {Time.now}
+    end
+
+    trait :review_complete do 
+      box
+      reviewed_by_id {create(:user, :reviewer).id}
+      reviewed_at {Time.now}
+      aasm_state {"reviewed"}
+    end
+
+
     summary { "This is a summary." }
     question_re_affect { "Question re effect." }
     question_re_referral_source { "Question about referral source." }

--- a/spec/factories/box_request.rb
+++ b/spec/factories/box_request.rb
@@ -2,12 +2,12 @@ FactoryBot.define do
   factory :box_request, aliases: [:messageable] do
     requester
 
-    trait :has_reviewer do
+    trait :review_in_progress do
       reviewed_by_id {create(:user, :reviewer).id}
       reviewed_at {Time.now}
     end
 
-    trait :review_complete do 
+    trait :reviewed do 
       box
       reviewed_by_id {create(:user, :reviewer).id}
       reviewed_at {Time.now}

--- a/spec/factories/inventory_type.rb
+++ b/spec/factories/inventory_type.rb
@@ -2,5 +2,16 @@ FactoryBot.define do
   factory :inventory_type do
     name { Faker::House.furniture.titleize }
     description { Faker::Lorem.sentence }
+
+    trait :needs_research do
+      description {"An inventory type that needs research"}
+      requires_research {true}
+    end
+
+    trait :no_research do
+      description {"An inventory type that doesn't need research"}
+      requires_research {false}
+    end
+    
   end
 end

--- a/spec/models/box_spec.rb
+++ b/spec/models/box_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe Box, :type => :model do
   let(:follow_upper) { create(:user, :follow_upper) }
   let(:inventory_type_research_needed) { create(:inventory_type, requires_research: true) }
   let(:inventory_type_no_research_needed) { create(:inventory_type, requires_research: false) }
+  let(:box_request) { create(:box_request, :has_reviewer) }
+  let(:reviewed_box_request) { create(:box_request, :review_complete) }
+  let(:box) { create(:box, :is_designed)  }
 
   describe "state transitions" do
     before(:each) do
@@ -24,20 +27,14 @@ RSpec.describe Box, :type => :model do
     end
 
     it "has state reviewed after box_request is reviewed" do
-      box_request_1.reviewed_by_id = reviewer.id;
-      box_request_1.save
-      box_request_1.claim_review!
-      box_request_1.complete_review!
-      box = box_request_1.box
+      box_request.claim_review!
+      box_request.complete_review!
+      box = box_request.box
       expect(box.aasm_state).to eq("reviewed")
     end
 
     it "transitions from reviewed to design_in_progress" do
-      box_request_1.reviewed_by_id = reviewer.id;
-      box_request_1.save
-      box_request_1.claim_review!
-      box_request_1.complete_review!
-      box = box_request_1.box
+      box = reviewed_box_request.box
       box.designed_by_id = designer.id;
       box.save
       expect(box).to transition_from(:reviewed).to(:design_in_progress).on_event(:claim_design)

--- a/spec/models/box_spec.rb
+++ b/spec/models/box_spec.rb
@@ -2,13 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Box, :type => :model do
   let(:requester) { Requester.new(first_name: "Jane", last_name: "Doe", street_address: "122 Boggie Woogie Avenue", city: "Fairfax", state: "VA", zip: "22030", ok_to_email: true, ok_to_text: false, ok_to_call: false, ok_to_mail: true, underage: false) }
-  let(:box_request_1) {
-    BoxRequest.create(requester: requester,
-                      summary: "Lorem ipsum text.... Caramels tart sweet pudding pie candy lollipop.",
-                      question_re_affect: "Lorem ipsum text.... Tart jujubes candy canes pudding I love gummies.",
-                      question_re_current_situation: "Sweet roll cake pastry cookie.",
-                      question_re_referral_source: "Ice cream sesame snaps danish marzipan macaroon icing jelly beans.") }
-
+  let(:box_request_1) {create(:box_request)}
   let(:reviewer) { create(:user, :reviewer) }
   let(:designer) { create(:user, :designer) }
   let(:researcher) { create(:user, :researcher) }
@@ -17,7 +11,7 @@ RSpec.describe Box, :type => :model do
   let(:follow_upper) { create(:user, :follow_upper) }
   let(:inventory_type_research_needed) { create(:inventory_type, requires_research: true) }
   let(:inventory_type_no_research_needed) { create(:inventory_type, requires_research: false) }
-  let(:box_request) { create(:box_request, :has_reviewer) }
+  let(:box_request_with_reviewer) { create(:box_request, :has_reviewer) }
   let(:reviewed_box_request) { create(:box_request, :review_complete) }
   let(:box) { create(:box, :is_designed)  }
 
@@ -27,260 +21,86 @@ RSpec.describe Box, :type => :model do
     end
 
     it "has state reviewed after box_request is reviewed" do
-      box_request.claim_review!
-      box_request.complete_review!
-      box = box_request.box
+      box_request_with_reviewer.claim_review!
+      box_request_with_reviewer.complete_review!
+      box = box_request_with_reviewer.box
       expect(box.aasm_state).to eq("reviewed")
     end
 
     it "transitions from reviewed to design_in_progress" do
-      box = reviewed_box_request.box
-      box.designed_by_id = designer.id;
-      box.save
+      box = create(:box, :reviewed)
       expect(box).to transition_from(:reviewed).to(:design_in_progress).on_event(:claim_design)
     end
 
     it "transitions from design_in_progress to designed" do
-      box_request_1.reviewed_by_id = reviewer.id;
-      box_request_1.save
-      box_request_1.claim_review!
-      box_request_1.complete_review!
-      box = box_request_1.box
+      box = build(:box, :design_in_progress)
       allow(box).to receive(:send_research_solicitation_email!)
-      box.designed_by_id = designer.id;
-      box.save
       box.claim_design!
       box.check_has_box_items # make sure there are items
-      # make sure at least one item needs research
+      #add items that need research
       create(:box_item, box: box, inventory_type: inventory_type_research_needed)
       expect(box).to transition_from(:design_in_progress).to(:designed).on_event(:complete_design)
       expect(box).to have_received(:send_research_solicitation_email!)
     end
 
     it "transitions from design_in_progress to researched when research not needed" do
-      box_request_1.reviewed_by_id = reviewer.id;
-      box_request_1.save
-      box_request_1.claim_review!
-      box_request_1.complete_review!
-      box = box_request_1.box
+      box = build(:box, :design_in_progress)
       allow(box).to receive(:send_assembly_solicitation_email!)
-      box.designed_by_id = designer.id;
-      box.save
-      box.claim_design!
+      #box.claim_design!
       box.check_has_box_items # make sure there are items
-      # make sure at least one item needs research
-      create(:box_item, box: box, inventory_type: inventory_type_no_research_needed)
+      # add item that doesn't require research
+      create(:box_item, box: box)
       expect(box).to transition_from(:design_in_progress).to(:researched).on_event(:complete_design)
       expect(box).to have_received(:send_assembly_solicitation_email!)
     end
 
     it "transitions from designed to research_in_progress" do
-      box_request_1.reviewed_by_id = reviewer.id;
-      box_request_1.save
-      box_request_1.claim_review!
-      box_request_1.complete_review!
-      box = box_request_1.box
-      box.designed_by_id = designer.id;
-      box.save
-      box.claim_design!
-      box.check_has_box_items # make sure there are items
-      # make sure at least one item needs research
-      create(:box_item, box: box, inventory_type: inventory_type_research_needed)
-      box.complete_design!
+      box = build(:box, :designed)
       box.researched_by_id = researcher.id;
-      box.save
       expect(box).to transition_from(:designed).to(:research_in_progress).on_event(:claim_research)
     end
 
     it "transitions from research_in_progress to researched" do
       time_now = Time.parse("Oct 11 2019")
       allow(Time).to receive(:now).and_return(time_now)
-
-      box_request_1.reviewed_by_id = reviewer.id;
-      box_request_1.save
-      box_request_1.claim_review!
-      box_request_1.complete_review!
-      box = box_request_1.box
-      box.designed_by_id = designer.id;
-      box.save
-      box.claim_design!
-      box.check_has_box_items # make sure there are items
-      expect(box).to receive(:send_research_solicitation_email!).and_return(true)
-
-      # make sure at least one item needs research
-      create(:box_item, box: box, inventory_type: inventory_type_research_needed)
-      box.complete_design!
-      box.researched_by_id = researcher.id;
-      box.save
-      box.claim_research!
+      box = build(:box, :research_in_progress)
       box.mark_box_items_as_researched!
       expect(box).to transition_from(:research_in_progress).to(:researched).on_event(:complete_research)
       expect(box.researched_at).to eq(time_now)
     end
 
     it "transitions from researched to assembly in progress" do
-      box_request_1.reviewed_by_id = reviewer.id;
-      box_request_1.save
-      box_request_1.claim_review!
-      box_request_1.complete_review!
-      box = box_request_1.box
-      box.designed_by_id = designer.id;
-      box.save
-      box.claim_design!
-      box.check_has_box_items # make sure there are items
-      # make sure at least one item needs research
-      create(:box_item, box: box, inventory_type: inventory_type_research_needed)
-      box.complete_design!
-      box.researched_by_id = researcher.id;
-      box.save
-      box.claim_research!
-      box.mark_box_items_as_researched!
-      box.complete_research!
+      box = build(:box, :researched)
       box.assembled_by_id = assembler.id;
-      box.save
       expect(box).to transition_from(:researched).to(:assembly_in_progress).on_event(:claim_assembly)
     end
 
-    it "transitons from assembly_in_progress to assembled" do
-      box_request_1.reviewed_by_id = reviewer.id;
-      box_request_1.save
-      box_request_1.claim_review!
-      box_request_1.complete_review!
-      box = box_request_1.box
+    it "transitions from assembly_in_progress to assembled" do
+      box = build(:box, :assembly_in_progress)
       allow(box).to receive(:send_shipping_solicitation_email!)
-      box.designed_by_id = designer.id;
-      box.save
-      box.claim_design!
-      box.check_has_box_items # make sure there are items
-      # make sure at least one item needs research
-      create(:box_item, box: box, inventory_type: inventory_type_research_needed)
-      box.complete_design!
-      box.researched_by_id = researcher.id;
-      box.save
-      box.claim_research!
-      box.mark_box_items_as_researched!
-      box.complete_research!
-      box.assembled_by_id = assembler.id;
-      box.save
-      box.claim_assembly!
       expect(box).to transition_from(:assembly_in_progress).to(:assembled).on_event(:complete_assembly)
       expect(box).to have_received(:send_shipping_solicitation_email!)
     end
 
-    it "transitons from assembled to shipping_in_progress" do
-      box_request_1.reviewed_by_id = reviewer.id;
-      box_request_1.save
-      box_request_1.claim_review!
-      box_request_1.complete_review!
-      box = box_request_1.box
-      box.designed_by_id = designer.id;
-      box.save
-      box.claim_design!
-      box.check_has_box_items # make sure there are items
-      # make sure at least one item needs research
-      create(:box_item, box: box, inventory_type: inventory_type_research_needed)
-      box.complete_design!
-      box.researched_by_id = researcher.id;
-      box.save
-      box.claim_research!
-      box.mark_box_items_as_researched!
-      box.complete_research!
-      box.assembled_by_id = assembler.id;
-      box.save
-      box.claim_assembly!
+    it "transitions from assembled to shipping_in_progress" do
+      box = build(:box, :assembled)
       box.shipped_by_id = shipper.id;
-      box.save
-      box.complete_assembly!
       expect(box).to transition_from(:assembled).to(:shipping_in_progress).on_event(:claim_shipping)
     end
 
-    it "transitons from shipping in progress to shipped" do
-      box_request_1.reviewed_by_id = reviewer.id;
-      box_request_1.save
-      box_request_1.claim_review!
-      box_request_1.complete_review!
-      box = box_request_1.box
-      box.designed_by_id = designer.id;
-      box.save
-      box.claim_design!
-      box.check_has_box_items # make sure there are items
-      # make sure at least one item needs research
-      create(:box_item, box: box, inventory_type: inventory_type_research_needed)
-      box.complete_design!
-      box.researched_by_id = researcher.id;
-      box.save
-      box.claim_research!
-      box.mark_box_items_as_researched!
-      box.complete_research!
-      box.assembled_by_id = assembler.id;
-      box.save
-      box.claim_assembly!
-      box.shipped_by_id = shipper.id;
-      box.save
-      box.complete_assembly!
-      box.claim_shipping!
+    it "transitions from shipping in progress to shipped" do
+      box = build(:box, :shipping_in_progress)
       expect(box).to transition_from(:shipping_in_progress).to(:shipped).on_event(:complete_shipping)
     end
 
-    it "transitons from shipped to follow_up_in_progress" do
-      box_request_1.reviewed_by_id = reviewer.id;
-      box_request_1.save
-      box_request_1.claim_review!
-      box_request_1.complete_review!
-      box = box_request_1.box
-      box.designed_by_id = designer.id;
-      box.save
-      box.claim_design!
-      box.check_has_box_items # make sure there are items
-      # make sure at least one item needs research
-      create(:box_item, box: box, inventory_type: inventory_type_research_needed)
-      box.complete_design!
-      box.researched_by_id = researcher.id;
-      box.save
-      box.claim_research!
-      box.mark_box_items_as_researched!
-      box.complete_research!
-      box.assembled_by_id = assembler.id;
-      box.save
-      box.claim_assembly!
-      box.shipped_by_id = shipper.id;
-      box.save
-      box.complete_assembly!
-      box.claim_shipping!
+    it "transitions from shipped to follow_up_in_progress" do
+      box = create(:box, :shipped)
       box.followed_up_by_id = follow_upper.id;
-      box.save
       expect(box).to transition_from(:shipped).to(:follow_up_in_progress).on_event(:claim_follow_up)
     end
 
-    it "transitons from follow_up_in_progress to followed up" do
-      box_request_1.reviewed_by_id = reviewer.id;
-      box_request_1.save
-      box_request_1.claim_review!
-      box_request_1.complete_review!
-      box = box_request_1.box
-      box.designed_by_id = designer.id;
-      box.save
-      box.claim_design!
-      box.check_has_box_items # make sure there are items
-      # make sure at least one item needs research
-      create(:box_item, box: box, inventory_type: inventory_type_research_needed)
-      box.complete_design!
-      box.researched_by_id = researcher.id;
-      box.save
-      box.claim_research!
-      box.mark_box_items_as_researched!
-      box.complete_research!
-      box.assembled_by_id = assembler.id;
-      box.save
-      box.claim_assembly!
-      box.shipped_by_id = shipper.id;
-      box.save
-      box.complete_assembly!
-      box.claim_shipping!
-      box.complete_shipping!
-      box.followed_up_by_id = follow_upper.id;
-      box.save
-      box.claim_follow_up!
+    it "transitions from follow_up_in_progress to followed up" do
+      box = create(:box, :follow_up_in_progress)
       expect(box).to transition_from(:follow_up_in_progress).to(:followed_up).on_event(:complete_follow_up)
     end
   end

--- a/spec/models/box_spec.rb
+++ b/spec/models/box_spec.rb
@@ -43,17 +43,17 @@ RSpec.describe Box, :type => :model do
     end
 
     it "transitions from design_in_progress to researched when research not needed" do
-      box = build(:box, :design_in_progress)
+      #build a box with one item that does not require research
+      box = build(:box, :designed_no_research)
       allow(box).to receive(:send_assembly_solicitation_email!)
       #box.claim_design!
-      # add item that doesn't require research
-      create(:box_item, box: box)
       expect(box).to transition_from(:design_in_progress).to(:researched).on_event(:complete_design)
       expect(box).to have_received(:send_assembly_solicitation_email!)
     end
 
     it "transitions from designed to research_in_progress" do
-      box = build(:box, :designed)
+      #build a box with one item that does require research
+      box = build(:box, :designed_needs_research)
       box.researched_by_id = researcher.id
       expect(box).to transition_from(:designed).to(:research_in_progress).on_event(:claim_research)
     end


### PR DESCRIPTION
Resolves #310  

### Description

Adds factory bot traits for a cleaner test suite and faster item creation.

The following traits are available:

**Inventory Type**
Creates an inventory type with ```research_required``` set appropriately to true or false.
- Needs research
- No research

**Box Item:**
Creates a box item and the necessary inventory type (using inventory_type traits), and associates box item with inventory type.
- Needs Research
- No Research

**Box Request:**
- Has Reviewer
- Review Complete

**Box:**
Sets the state as appropriate and adds any needed fields for validity. Note that each successive trait inherits from the one before it, so ```create(:box, :design_in_progress)``` will also have all the associations as ```create(:box, :reviewed)```,  even though they aren't all explicitly stated in the factory trait.
- Reviewed
- Design in Progress
- Designed
- Research in Progress
- Researched
- Assembly in Progress
- Assembled
- Shipping in Progress
- Shipped
- Follow Up in Progress
- Followed Up

### Type of change

- New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

The box_spec tests all pass as expected using the created FactoryBot traits.