### PR TITLE
Pin redis vers, use local mailcatcher dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - "127.0.0.1:6379:6379"
   mailcatcher:
     build:
-      context: ./Dockerfiles
+      context: ./dockerfiles
       dockerfile: mailcatcher
     command: ["mailcatcher", "--foreground", "--ip=0.0.0.0", "--smtp-port=1025", "--http-port=1080"]
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 version: '3.2'
 services:
+
   db:
     image: postgres:11.4
     ports:
@@ -7,11 +8,13 @@ services:
     environment:
       - POSTGRES_USER=${USER}
   redis:
-    image: redis:latest
+    image: redis:5.0
     ports:
       - "127.0.0.1:6379:6379"
   mailcatcher:
-    image: tophfr/mailcatcher
+    build:
+      context: ./Dockerfiles
+      dockerfile: mailcatcher
     command: ["mailcatcher", "--foreground", "--ip=0.0.0.0", "--smtp-port=1025", "--http-port=1080"]
     ports:
       - "127.0.0.1:1080:1080"

--- a/dockerfiles/mailcatcher
+++ b/dockerfiles/mailcatcher
@@ -1,0 +1,26 @@
+FROM alpine:3.9
+
+MAINTAINER toph <toph@toph.fr>
+
+RUN apk add --no-cache ca-certificates openssl
+
+RUN apk add --no-cache \
+        ruby \
+        ruby-bigdecimal \
+        ruby-etc \
+        ruby-json \
+        libstdc++ \
+        sqlite-libs
+
+ARG MAILCATCHER_VERSION=0.7.1
+
+RUN apk add --no-cache --virtual .build-deps \
+        ruby-dev \
+        make g++ \
+        sqlite-dev \
+    && gem install -v $MAILCATCHER_VERSION mailcatcher --no-ri --no-rdoc \
+    && apk del .build-deps
+
+EXPOSE 25 80
+
+CMD ["mailcatcher", "--foreground", "--ip=0.0.0.0", "--smtp-port=25", "--http-port=80"]


### PR DESCRIPTION
Pin to a specific redis version to avoid breaking changes with :latest, and make the mailcatcher Dockerfile local (since it's not coming from a verified repository, this future-proofs in case something happens to that repository).