### PR TITLE
Add after_create callback to location model

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -9,6 +9,8 @@ class Location < ApplicationRecord
   validates :name, presence: true
   validates :location_type, presence: true
 
+  after_create :create_inventory_tallies, if: :storage_unit?
+
   enum location_type: {
     # Example types from ERD
     storage_unit: 0,
@@ -19,4 +21,11 @@ class Location < ApplicationRecord
     university: 5
   }
 
+  private
+
+  def create_inventory_tallies
+    InventoryType.all.each do |inventory_type|
+      inventory_tallies.create(inventory_type: inventory_type)
+    end
+  end
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -51,4 +51,17 @@ RSpec.describe Location, type: :model do
     foreign_key: 'assembly_location_id',
     inverse_of: :assembly_location
   }
+
+  context 'after_create' do
+    context 'when location_type is storage_unit' do
+      before do
+        create_list(:inventory_type, 4)
+      end
+
+      it 'should create a InventoryTally to each InventoryType' do
+        location = create(:location, location_type: "storage_unit")
+        expect(InventoryTally.where(storage_location: location).count).to eq(4)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves #429 

### Description

As described on the issue:

* When a new location with storage_unit location type is created the
  callback funtion create_inventory_tallies generates a InventoryTally
  for each InventoryType

### Type of change

- New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Running the existing tests and new tests locally.
