### PR TITLE
replacing images for icons in menu

### DIFF
--- a/app/javascript/src/stylesheets/_navigation.scss
+++ b/app/javascript/src/stylesheets/_navigation.scss
@@ -2,6 +2,7 @@ $nav-background: #eee;
 $nav-color: #ddd;
 $nav-text-color: #888;
 $border-color: rgb(170, 150, 153);
+$icon-color: #dea9b2;
 
 .app-nav {
   background-color: $nav-background;
@@ -61,6 +62,10 @@ $border-color: rgb(170, 150, 153);
         max-height: 80px;
       }
     }
+  }
+
+  a.nav-icon {
+    color: $icon-color;
   }
 
   .nav-item {

--- a/app/javascript/src/stylesheets/application.scss
+++ b/app/javascript/src/stylesheets/application.scss
@@ -36,7 +36,7 @@ body {
 }
 
 .flash-messages {
-    margin-left: 10px;
+  margin-left: 10px;
 }
 
 .app-nav {
@@ -45,7 +45,7 @@ body {
   left: 0;
   right: 0;
   width: 100%;
-  height: 80px;
+  height: 60px;
   color: #ddd;
   background-color: #eee;
   z-index: 3;

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -4,25 +4,25 @@
   <% end %>
   <% if user_signed_in? %>
     <%= link_to box_requests_path, class: 'nav-icon' do %>
-      <i class="fas fa-user-clock"></i>
+      <i class="fas fa-user-clock" aria-hidden="true" role="presentation"></i>
       <span>Status</span>
     <% end %>
 
     <% if current_user.is_admin? %>
       <a class="nav-icon" href="/box_requests?filter_by=review_in_progress">
-        <i class="fas fa-address-card"></i>
+        <i class="fas fa-address-card" aria-hidden="true" role="presentation"></i>
         <span>Review</span>
       </a>
       <a class="nav-icon" href="/box_requests?filter_by=design_in_progress">
-        <i class="fas fa-object-group"></i>
+        <i class="fas fa-object-group" aria-hidden="true" role="presentation"></i>
         <span>Design</span>
       </a>
       <a class="nav-icon" href="/box_requests?filter_by=assembly_in_progress">
-        <i class="fas fa-box-open"></i>
+        <i class="fas fa-box-open" aria-hidden="true" role="presentation"></i>
         <span>Packing</span>
       </a>
       <a class="nav-icon" href="/box_requests?filter_by=shipping_in_progress">
-        <i class="fas fa-box"></i>
+        <i class="fas fa-box" aria-hidden="true" role="presentation"></i>
         <span>Shipping</span>
       </a>
     <% else %>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -4,25 +4,25 @@
   <% end %>
   <% if user_signed_in? %>
     <%= link_to box_requests_path, class: 'nav-icon' do %>
-      <img src="https://voices-of-consent-static-images.s3.amazonaws.com/Status.svg" title="Status" />
+      <i class="fas fa-user-clock"></i>
       <span>Status</span>
     <% end %>
 
     <% if current_user.is_admin? %>
       <a class="nav-icon" href="/box_requests?filter_by=review_in_progress">
-        <img src="https://voices-of-consent-static-images.s3.amazonaws.com/Review+Stage.svg" title="Review">
+        <i class="fas fa-address-card"></i>
         <span>Review</span>
       </a>
       <a class="nav-icon" href="/box_requests?filter_by=design_in_progress">
-        <img src="https://voices-of-consent-static-images.s3.amazonaws.com/Design+Stage.svg" title="Design">
+        <i class="fas fa-object-group"></i>
         <span>Design</span>
       </a>
       <a class="nav-icon" href="/box_requests?filter_by=assembly_in_progress">
-        <img src="https://voices-of-consent-static-images.s3.amazonaws.com/Packing+Stage.svg" title="Packing">
+        <i class="fas fa-box-open"></i>
         <span>Packing</span>
       </a>
       <a class="nav-icon" href="/box_requests?filter_by=shipping_in_progress">
-        <img src="https://voices-of-consent-static-images.s3.amazonaws.com/Shipping+boc+redux.svg" title="Shipping">
+        <i class="fas fa-box"></i>
         <span>Shipping</span>
       </a>
     <% else %>

--- a/spec/views/shared/_navigation.html.erb_spec.rb
+++ b/spec/views/shared/_navigation.html.erb_spec.rb
@@ -72,5 +72,15 @@ RSpec.describe 'shared/_navigation.html.erb', type: :view do
       assert_select "a[href='#{base_url}shipping_in_progress']",
                     text: 'Shipping', count: 1
     end
+
+    it 'renders menu icons' do
+      render
+
+      assert_select 'i', class: 'fas fa-user-clock'
+      assert_select 'i', class: 'fas fa-address-card'
+      assert_select 'i', class: 'fas fa-object-group'
+      assert_select 'i', class: 'fas fa-box-open'
+      assert_select 'i', class: 'fas fa-box'
+    end
   end
 end


### PR DESCRIPTION
# Checklist:
- I have performed a self-review of my own code,
- New and existing unit tests pass locally with my changes ("bundle exec rake")

### Description
I have a proposal to change the menu, I think it's too big and I think it would be better to use icons instead of images.

### Type of change

- Improvement

### Screenshots
old:
![Screen Shot 2020-03-29 at 23 31 33](https://user-images.githubusercontent.com/25162312/77869971-94d42700-7216-11ea-8c2c-0a266333f84c.png)
new:
![Screen Shot 2020-03-29 at 23 27 30](https://user-images.githubusercontent.com/25162312/77869986-9e5d8f00-7216-11ea-8ac5-8a32e7d04bd5.png)

