### PR TITLE
adding spec coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,8 @@ yarn-debug.log*
 /storage/*
 !/storage/.keep
 
+# Ignore simple-cov files
+/coverage
 
 .tool-versions
 .rails_routes_rb~

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ group :test do
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'webdrivers', '~> 4.0'
   gem 'shoulda-matchers'
+  gem 'simplecov', require: false
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
       actionmailer (>= 5.0)
       devise (>= 4.6)
     diff-lcs (1.3)
+    docile (1.3.2)
     erubi (1.9.0)
     factory_bot (5.0.2)
       activesupport (>= 4.2.0)
@@ -115,6 +116,7 @@ GEM
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
     jmespath (1.4.0)
+    json (2.3.0)
     jwt (2.2.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -238,6 +240,11 @@ GEM
     simple_form (5.0.0)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
+    simplecov (0.17.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -311,6 +318,7 @@ DEPENDENCIES
   shoulda-matchers
   sidekiq
   simple_form
+  simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
   twilio-ruby (~> 5.25)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,7 +9,6 @@ require 'rspec/rails'
 if ENV['RAILS_ENV'] == 'test'
   require 'simplecov'
   SimpleCov.start 'rails'
-  puts "required simplecov"
 end
 
 require_relative 'support/controller_macros'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,12 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 
+if ENV['RAILS_ENV'] == 'test'
+  require 'simplecov'
+  SimpleCov.start 'rails'
+  puts "required simplecov"
+end
+
 require_relative 'support/controller_macros'
 require_relative 'support/authentication_helpers'
 require_relative 'support/shoulda.rb'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,8 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
 
+  require 'simplecov'
+  SimpleCov.start 'rails'
 #  config.include Capybara::DSL
 
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
# Checklist:
- I have performed a self-review of my own code,
- New and existing unit tests pass locally with my changes ("bundle exec rake")

### Description
I was working on an issue and I would like to know what the percentage of testing coverage is, so I added a gem that shows this coverage, to have control over what is being tested and what is not yet.

### Type of change

- Improvement

## Output
`Coverage report generated for RSpec to voices-of-consent/coverage. (50.64%) covered.`
