### PR TITLE
Issue 20

### DIFF
--- a/app/controllers/inventory_tallies_controller.rb
+++ b/app/controllers/inventory_tallies_controller.rb
@@ -4,7 +4,8 @@ class InventoryTalliesController < ApplicationController
   # GET /inventory_tallies
   # GET /inventory_tallies.json
   def index
-    @inventory_tallies = InventoryTally.all.includes(:storage_location, :inventory_type)
+    @inventory_tallies = filter_tally || InventoryTally.all.includes(:storage_location, :inventory_type)
+  
   end
 
   # GET /inventory_tallies/1
@@ -72,5 +73,13 @@ class InventoryTalliesController < ApplicationController
       params.require(:inventory_tally).permit(:additional_location_info,
                                               :inventory_type_id,
                                               :storage_location_id)
+    end
+    def filter_params
+      params.permit(:additional_location_info,
+                    :inventory_type_id,
+                    :storage_location_id)
+    end
+    def filter_tally
+      InventoryTally.where(filter_params).includes(:storage_location, :inventory_type) unless filter_params.empty?
     end
 end

--- a/app/javascript/src/components/box-assembly-form/BoxAssemblyForm.jsx
+++ b/app/javascript/src/components/box-assembly-form/BoxAssemblyForm.jsx
@@ -150,8 +150,10 @@ const BoxAssemblyForm = () => {
         })
       console.log("Inventory tallies: ", inventoryTallies);
       Promise.all(inventoryTallies).then(allResponse=>{
-          console.log ("Got response: ", allResponse);
-      });
+          return Promise.all(allResponse.map(aResp=>aResp.json()));
+      }).then(json=>{
+        json.forEach(aJson=>console.log(aJson));
+      })
     }
 
   }

--- a/app/javascript/src/components/box-assembly-form/BoxAssemblyForm.jsx
+++ b/app/javascript/src/components/box-assembly-form/BoxAssemblyForm.jsx
@@ -6,7 +6,6 @@ const BoxAssemblyForm = () => {
   const [items, updateItems] = useState(null);
   const [isAssembled, updateIsAssembled] = useState(false);
   const [selectedLocation, setLocation] = useState(null);
-  // const [selectedInventoryTally, setSelectedInventoryTally] = useState({});
   const [submitedState, setSubmittedState] = useState(null);
 
   useEffect(() => {

--- a/app/javascript/src/components/box-assembly-form/BoxAssemblyForm.jsx
+++ b/app/javascript/src/components/box-assembly-form/BoxAssemblyForm.jsx
@@ -6,7 +6,8 @@ const BoxAssemblyForm = () => {
   const [items, updateItems] = useState(null);
   const [isAssembled, updateIsAssembled] = useState(false);
   const [selectedLocation, setLocation] = useState(null);
-  const [selectedInventoryTally, setSelectedInventoryTall] = useState({});
+  const [selectedInventoryTally, setSelectedInventoryTally] = useState({});
+  const [submitedState, setSubmittedState] = useState([]);
 
   useEffect(() => {
     // API call to return predetermined box items.
@@ -23,6 +24,7 @@ const BoxAssemblyForm = () => {
           return item;
         })
         updateItems(unassembledItemChecklist);
+        setSubmittedState(unassembledItemChecklist);
       });
   }, [])
 
@@ -55,71 +57,95 @@ const BoxAssemblyForm = () => {
     }
   }, [items])
 
-  const updateAssemblyStatus = (index) => {
-    var clickedItem = items.filter((anItem, i)  => {
-        return i == index;
-    })[0];
+  // const updateAssemblyStatus = (index) => {
 
-    if (!selectedInventoryTally[clickedItem.id]) {
-      //Go out and get a tally
-      fetch(`/inventory_tallies.json/?storage_location_id=` + selectedLocation.id + `&inventory_type_id` + `=` + clickedItem.id)
-        .then(response => response.json())
-        .then((data) => {
-          if (data && Array.isArray(data) && data.length > 0) {
+  //   var clickedItem = items.filter((anItem, i) => {
+  //     return i == index;
+  //   })[0];
 
-            var updatedTally = { ...selectedInventoryTally };
-            updatedTally[clickedItem.id] = data[0];
-            setSelectedInventoryTall(updatedTally);
-            updateInventoryTally(data[0].id,clickedItem.id, clickedItem.checked ? 1 : -1,index)
-            //Create a new Inventory Tally, based on state
-          } else {
-            console.error("Try again?");
-          }
+  //   if (!selectedInventoryTally[clickedItem.id]) {
+  //     //Go out and get a tally
+  //     fetch(`/inventory_tallies.json/?storage_location_id=` + selectedLocation.id + `&inventory_type_id` + `=` + clickedItem.id)
+  //       .then(response => response.json())
+  //       .then((data) => {
+  //         if (data && Array.isArray(data) && data.length > 0) {
 
-        });
-    } else {
-      updateInventoryTally(selectedInventoryTally[clickedItem.id].id,clickedItem.id, clickedItem.checked ? 1 : -1,index)
-    }
-    
+  //           var updatedTally = { ...selectedInventoryTally };
+  //           updatedTally[clickedItem.id] = data[0];
+  //           setSelectedInventoryTally(updatedTally);
+  //           updateInventoryTally(data[0].id, clickedItem.id, clickedItem.checked ? 1 : -1, index)
+  //           //Create a new Inventory Tally, based on state
+  //         } else {
+  //           console.error("Try again?");
+  //         }
+
+  //       });
+  //   } else {
+  //     updateInventoryTally(selectedInventoryTally[clickedItem.id].id, clickedItem.id, clickedItem.checked ? 1 : -1, index)
+  //   }
+
+  // }
+
+
+  const updateCheckboxState = (index) => {
+    console.log(typeof items);
+    var newState = items.map((anItem, i) => {
+      var returnItem = anItem;
+      if(i === index) {
+        returnItem.checked = !returnItem.checked;
+      }
+
+      return returnItem;
+    });
+
+    updateItems(newState);
   }
 
-  const updateInventoryTally = (inventory_tally_id, box_item_id, adjustment_quantity,index) =>{
-    console.log("Updated: ", inventory_tally_id,' box= ',box_item_id,'adj= ',adjustment_quantity)
-    var opts = {
-      inventory_tally_id: inventory_tally_id,
-      box_item_id: box_item_id,
-      adjustment_quantity: adjustment_quantity
-    }
+  // const updateInventoryTally = (inventory_tally_id, box_item_id, adjustment_quantity, index) => {
+
+  //   var opts = {
+  //     inventory_tally_id: inventory_tally_id,
+  //     box_item_id: box_item_id,
+  //     adjustment_quantity: adjustment_quantity
+  //   }
+
+
+  //   fetch(`/inventory_adjustments.json/`, {
+  //     method: 'POST',
+  //     body: JSON.stringify(opts),
+  //     headers: {
+  //       'Content-Type': 'application/json',
+  //       'Accept': 'application/json',
+  //       'X-Requested-With': 'XMLHttpRequest',
+  //       'X-CSRF-Token': token
+  //     }
+  //   })
+  //     .then(response => response.json())
+  //     .then((data) => {
+  //       console.log("Response: ", data);
+  //       const updatedItems = items.map((item, i) => {
+  //         if (i === index) {
+  //           item.checked = !item.checked;
+  //         }
+  //         return item;
+  //       })
+  //       updateItems(updatedItems);
+  //     });
+  // };
+
+  const tallySubmitted = () => {
+
     const token = document.getElementsByName('csrf-token')[0].content
 
-    fetch(`/inventory_adjustments.json/`,{
-      method: 'POST',
-      body: JSON.stringify(opts),
-      headers: {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json',
-        'X-Requested-With': 'XMLHttpRequest',
-        'X-CSRF-Token': token
-      }
-    })
-        .then(response => response.json())
-        .then((data) => {
-          console.log("Response: ",data);
-          const updatedItems = items.map((item, i) => {
-            if (i === index) {
-              item.checked = !item.checked;
-            }
-            return item;
-          })
-          updateItems(updatedItems);
-        });
-  };
+    console.log("Checkboxes are: ", items);
+
+  }
 
   var locationReadout = (selectedLocation) ? <div>{selectedLocation.name}</div> : [];
 
   return (
     <main className="box-assembly">
-      <h2 className="box-assembly__header">Box Packing Checklist</h2>
+      <h2 className="box-assembly__header">1 Box Packing Checklist</h2>
 
       <section className="text-box">
         <p>Please check items as you add them to the box.</p>
@@ -135,7 +161,7 @@ const BoxAssemblyForm = () => {
               enabled={selectedLocation ? true : false}
               key={i}
               updateCheckStatus={() => {
-                updateAssemblyStatus(i);
+                updateCheckboxState(i);
               }}
               {...item}
             />
@@ -146,10 +172,7 @@ const BoxAssemblyForm = () => {
         <button
           className={`${isAssembled ? 'active' : ''}`}
           disabled={!items}
-          onClick={() => {
-            // TODO: AJAX Call
-            console.log(items)
-          }}
+          onClick={tallySubmitted}
         >{!isAssembled ? 'Waiting' : 'The box is ready to go'}</button>
       </section>
     </main>

--- a/app/javascript/src/components/box-assembly-form/BoxAssemblyForm.jsx
+++ b/app/javascript/src/components/box-assembly-form/BoxAssemblyForm.jsx
@@ -45,6 +45,7 @@ const BoxAssemblyForm = () => {
       }
       return item;
     })
+    console.log("CHRIS: updated items= ", updatedItems);
     updateItems(updatedItems);
   }
 

--- a/app/javascript/src/components/box-assembly-form/BoxAssemblyForm.jsx
+++ b/app/javascript/src/components/box-assembly-form/BoxAssemblyForm.jsx
@@ -140,7 +140,7 @@ const BoxAssemblyForm = () => {
       const token = document.getElementsByName('csrf-token')[0].content
       var inventoryTallies =  items.map((anItem, index) => {
 
-        if (anItem.checked != submitedState[index].checked) {
+        if (anItem.checked != submitedState[index]) {
           return anItem;
         }
         return undefined;

--- a/app/javascript/src/components/box-assembly-form/BoxAssemblyForm.jsx
+++ b/app/javascript/src/components/box-assembly-form/BoxAssemblyForm.jsx
@@ -34,7 +34,7 @@ const BoxAssemblyForm = () => {
       .then((data) => {
         if(data && Array.isArray(data) && data.length > 0) {
           //Pick the first location
-          console.log("Setting location",data[0]);
+          console.debug("Setting location",data[0]);
           setLocation(data[0]);
         }
       });
@@ -62,6 +62,18 @@ const BoxAssemblyForm = () => {
       return item;
     })
 
+    // //Go out and get a tally
+    // fetch(`/locations.json?location_type=storage_unit`)
+    //   .then(response => response.json())
+    //   .then((data) => {
+    //     if(data && Array.isArray(data) && data.length > 0) {
+    //       //Pick the first location
+    //       console.log("Setting location",data[0]);
+    //       setLocation(data[0]);
+    //     }
+    //   });
+
+
     updateItems(updatedItems);
   }
 
@@ -82,6 +94,7 @@ const BoxAssemblyForm = () => {
           items &&
             items.map((item, i) => (
               <ItemChecker 
+                enabled={selectedLocation ? true : false}
                 key={ i }
                 updateCheckStatus={ () => {
                   updateAssemblyStatus(i);

--- a/app/javascript/src/components/box-assembly-form/BoxAssemblyForm.jsx
+++ b/app/javascript/src/components/box-assembly-form/BoxAssemblyForm.jsx
@@ -156,7 +156,12 @@ const BoxAssemblyForm = () => {
   var locationReadout = (selectedLocation) ? <div>{selectedLocation.name}</div> : [];
 
   var buttonDisabled = !items ||  items.filter((anItem,index)=>{
-    return anItem.checked === submitedState[index];
+
+    if(submitedState) {
+      return anItem.checked === submitedState[index];
+    }
+    return true;
+    
   }).length == items.length;
 
   return (

--- a/app/javascript/src/components/box-assembly-form/BoxAssemblyForm.jsx
+++ b/app/javascript/src/components/box-assembly-form/BoxAssemblyForm.jsx
@@ -5,6 +5,7 @@ import './BoxAssemblyForm.scss';
 const BoxAssemblyForm = () => {
   const [items, updateItems] = useState(null);
   const [isAssembled, updateIsAssembled] = useState(false);
+  const [selectedLocation, setLocation] = useState(null);
 
   useEffect(() => {
     // API call to return predetermined box items.
@@ -21,6 +22,21 @@ const BoxAssemblyForm = () => {
           return item;
         })
         updateItems(unassembledItemChecklist);
+      });
+  }, [])
+
+  //Find a location to pull from:
+  useEffect(() => {
+
+    // API call to return predetermined box items.
+    fetch(`/locations.json?location_type=storage_unit`)
+      .then(response => response.json())
+      .then((data) => {
+        if(data && Array.isArray(data) && data.length > 0) {
+          //Pick the first location
+          console.log("Setting location",data[0]);
+          setLocation(data[0]);
+        }
       });
   }, [])
 
@@ -45,16 +61,19 @@ const BoxAssemblyForm = () => {
       }
       return item;
     })
-    console.log("CHRIS: updated items= ", updatedItems);
-    updateItems(updatedItems);
   }
 
+  var locationReadout = (selectedLocation) ?<div>{selectedLocation.name}</div> : [];
 
   return (
     <main className="box-assembly">
       <h2 className="box-assembly__header">Box Packing Checklist</h2>
+
       <section className="text-box">
         <p>Please check items as you add them to the box.</p>
+      </section>
+      <section className="text-box">
+        {selectedLocation && <p>Items are coming from: {locationReadout}</p>}
       </section>
       <section className="box-assembly__item-checker">
         {

--- a/app/javascript/src/components/box-assembly-form/BoxAssemblyForm.jsx
+++ b/app/javascript/src/components/box-assembly-form/BoxAssemblyForm.jsx
@@ -61,6 +61,8 @@ const BoxAssemblyForm = () => {
       }
       return item;
     })
+
+    updateItems(updatedItems);
   }
 
   var locationReadout = (selectedLocation) ?<div>{selectedLocation.name}</div> : [];

--- a/app/javascript/src/components/box-assembly-form/item-checker/ItemChecker.jsx
+++ b/app/javascript/src/components/box-assembly-form/item-checker/ItemChecker.jsx
@@ -5,6 +5,7 @@ const ItemChecker = ({
   count,
   checked,
   updateCheckStatus,
+  enabled
 }) => {
   return (
     <div className="item-checker">
@@ -12,6 +13,7 @@ const ItemChecker = ({
       <div className="item-checker__name">{ type }</div>
       <div className="item-checker__check-button">
         <input 
+          disabled = {enabled ? "" : "disabled"}
           type="checkbox"
           checked={ checked }
           onChange={e => {


### PR DESCRIPTION
Resolves #20 

### Description
The Box Packing Checklist page will now perform the following actions:
- At the loading of the page: The locations endpoint is queried to return the first matching location of type Storage Unit. The checkboxes will not be selectable until a location is returned. (May want to consider retry or selection for the location).

- When the user clicks on the check box, the following actions will take place:

1. The Inventory Tally for the selected location and check box item will be queried. Before performing the query the cache (which is just in memory) will check to see if an Inventory Tally has been found. If found the cached version will be used. 

1. An Inventory Adjustment will be made on the Inventory Tally. If the checkbox becomes checked, the inventory will be set to -1, otherwise it will be set to 1. 

1. Once a response is returned in the Inventory Adjusmtent, the checbox check state will be updated. 

### Type of change
- New feature (non-breaking change which adds functionality)
### How Has This Been Tested?
Currently a simple walk through has been done. When the Box Assembly has been loaded and a location has been returned, I tested the checkboxes by manually clicking the boxes and verifying that the content of the InventoryAdjustment has change. There are some edge cases that need to be resolved: 

1. What to do when a Inventory Tally is not found? There was a discussion in the ticket on how to proceed. For now recommend creating a separate ticket to handle. 

1. How do we handle negative tallies? Right now there is no protection so the tallies can go negative. 
