### PR TITLE
Creating a callback on inventory_type to create tallies

### DIFF
--- a/app/models/inventory_type.rb
+++ b/app/models/inventory_type.rb
@@ -10,7 +10,9 @@ class InventoryType < ApplicationRecord
   def create_inventory_tallies
     locations = Location.where(location_type: "storage_unit")
     locations.each do |location|
-      inventory_tallies.create(storage_location: location)
+      InventoryType.all.each do |inventory_type|
+        inventory_tallies.create(storage_location: location, inventory_type: inventory_type)
+      end
     end
   end
 end

--- a/app/models/inventory_type.rb
+++ b/app/models/inventory_type.rb
@@ -8,8 +8,9 @@ class InventoryType < ApplicationRecord
   private
 
   def create_inventory_tallies
-    Location.all.each do |location|
-      inventory_tallies.create(storage_location: location) if location.storage_unit?
+    locations = Location.where(location_type: "storage_unit")
+    locations.each do |location|
+      inventory_tallies.create(storage_location: location)
     end
   end
 end

--- a/app/models/inventory_type.rb
+++ b/app/models/inventory_type.rb
@@ -2,4 +2,14 @@ class InventoryType < ApplicationRecord
   has_many :box_items
   has_many :core_box_items
   has_many :inventory_tallies
+
+  after_create :create_inventory_tallies
+
+  private
+
+  def create_inventory_tallies
+    Location.all.each do |location|
+      inventory_tallies.create(storage_location: location) if location.storage_unit?
+    end
+  end
 end

--- a/spec/models/inventory_type_spec.rb
+++ b/spec/models/inventory_type_spec.rb
@@ -22,16 +22,14 @@ RSpec.describe InventoryType, type: :model do
     inverse_of: :assembly_location
   }
 
-  context 'after_create' do
-    context 'when location_type is storage_unit' do
-      before do
-        create_list(:location, 4, location_type: "storage_unit")
-      end
+  let!(:location) { create_list(:location, 1, location_type: "storage_unit") }
+  let!(:inventory_type) { create_list(:inventory_type, 1) }
 
-      it 'should create a InventoryTally to each Location' do
-        inventory_type = create(:inventory_type)
-        expect(InventoryTally.where(inventory_type: inventory_type).count).to eq(4)
-      end
+  context 'after_create' do
+    subject(:create_inventory_type) { create(:inventory_type) }
+
+    it 'creates one inventory tally for each type location pair' do
+      expect { create_inventory_type }.to change { InventoryTally.count }.by 2
     end
   end
 end

--- a/spec/models/inventory_type_spec.rb
+++ b/spec/models/inventory_type_spec.rb
@@ -1,5 +1,37 @@
 require 'rails_helper'
 
 RSpec.describe InventoryType, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it { 
+    is_expected.to have_many(:box_items)
+    .class_name('BoxItem'),
+    foreign_key: 'inventory_type_id',
+    inverse_of: :assembly_location
+  }
+
+  it { 
+    is_expected.to have_many(:core_box_items)
+    .class_name('CoreBoxItem'),
+    foreign_key: 'inventory_type_id',
+    inverse_of: :assembly_location
+  }
+
+  it { 
+    is_expected.to have_many(:inventory_tallies)
+    .class_name('InventoryTally'),
+    foreign_key: 'inventory_type_id',
+    inverse_of: :assembly_location
+  }
+
+  context 'after_create' do
+    context 'when location_type is storage_unit' do
+      before do
+        create_list(:location, 4, location_type: "storage_unit")
+      end
+
+      it 'should create a InventoryTally to each Location' do
+        inventory_type = create(:inventory_type)
+        expect(InventoryTally.where(inventory_type: inventory_type).count).to eq(4)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves #454

### Description

Creates an after_create callback on inventory_type to create tallies on all locations that are storage units.

### Type of change

- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Created a spec for inventory_type.
